### PR TITLE
Update ad-1.template

### DIFF
--- a/templates/ad-1.template
+++ b/templates/ad-1.template
@@ -415,6 +415,9 @@
             "us-east-2": {
                 "WS2016FULLBASE": "ami-36241f53"
             },
+			"us-gov-west-1": {
+			    "WS2016FULLBASE": "ami-59c25238"
+			},
             "us-west-1": {
                 "WS2016FULLBASE": "ami-d12ecdb2"
             },
@@ -518,9 +521,19 @@
                                         "ssm:GetParameter"
                                     ],
                                     "Resource": {
-                                        "Fn::Sub": "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${ADPassword}"
-                                    }
-                                },
+                                        "Fn::Sub": [
+										    "arn:${Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${ADPassword}",
+											{
+                                                "Partition": {
+                                                    "Fn::If": [
+                                                        "GovCloudCondition",
+                                                        "aws-us-gov",
+                                                        "aws"
+                                                    ]
+                                                }
+                                            }
+										]
+                                    },
                                 {
                                     "Effect": "Allow",
                                     "Action": [


### PR DESCRIPTION
 Updated the AWSAMIRegionMap to include WS2016FULLBASE AMI for us-gov-west-1 region.  Updated the AD-SSM-Parameters policy associated with the ADServerRole resource to allow for GovCloud deployment by changing partition from aws to aws-us-gov dynamically based on GovCloudCondition.