### PR TITLE
Fixed the MaxLength of DomainDNSName to be 255 across all templates

### DIFF
--- a/templates/ad-3.template
+++ b/templates/ad-3.template
@@ -96,7 +96,7 @@
             "Type": "String",
             "Default": "example.com",
             "MinLength": "2",
-            "MaxLength": "25",
+            "MaxLength": "255",
             "AllowedPattern": "[a-zA-Z0-9\\-]+\\..+"
         },
         "DomainNetBIOSName": {

--- a/templates/ad-master-1.template
+++ b/templates/ad-master-1.template
@@ -221,7 +221,7 @@
             "AllowedPattern": "[a-zA-Z0-9\\-]+\\..+",
             "Default": "example.com",
             "Description": "Fully qualified domain name (FQDN) of the forest root domain e.g. example.com",
-            "MaxLength": "25",
+            "MaxLength": "255",
             "MinLength": "2",
             "Type": "String"
         },

--- a/templates/ad-master-2.template
+++ b/templates/ad-master-2.template
@@ -198,7 +198,7 @@
             "AllowedPattern": "[a-zA-Z0-9\\-]+\\..+",
             "Default": "example.com",
             "Description": "Fully qualified domain name (FQDN) of the forest root domain e.g. example.com",
-            "MaxLength": "25",
+            "MaxLength": "255",
             "MinLength": "2",
             "Type": "String"
         },


### PR DESCRIPTION
Fixed the MaxLength of DomainDNSName to be 255 across all templates. This is for the issue raised
https://github.com/aws-quickstart/quickstart-microsoft-activedirectory/issues/21