### PR TITLE
formatting,tagging,security,simplify

### DIFF
--- a/templates/ad-1.template
+++ b/templates/ad-1.template
@@ -1,17 +1,14 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >-
-  This template creates 2 Windows 2019 Active Directory Domain Controllers
-  into private subnets in separate Availability Zones inside a VPC. The default Domain
-  Administrator password will be the one retrieved from the instance.  For adding
-  members to the domain, ensure that they are launched into the domain member security
-  group created by this template and then configure them to use the AD instances fixed
-  private IP addresses as the DNS server. **WARNING** This template creates Amazon
-  EC2 Windows instance and related resources. You will be billed for the AWS resources
-  used if you create a stack from this template. (qs-1qup6rae5)
+  This template creates 2 Windows 2019 Active Directory Domain Controllers into private subnets in separate Availability Zones inside a VPC. The
+  default Domain Administrator password will be the one retrieved from the instance.  For adding members to the domain, ensure that they are launched
+  into the domain member security group created by this template and then configure them to use the AD instances fixed private IP addresses as the DNS
+  server. **WARNING** This template creates Amazon EC2 Windows instance and related resources. You will be billed for the AWS resources used if you
+  create a stack from this template. (qs-1qup6rae5)
 Metadata:
   QuickStartDocumentation:
-    EntrypointName: "Launch Active Directory on EC2 into an existing VPC"
-    Order: "2"
+    EntrypointName: 'Launch Active Directory on EC2 into an existing VPC'
+    Order: '2'
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
@@ -66,16 +63,6 @@ Metadata:
           - QSS3BucketRegion
           - QSS3KeyPrefix
     ParameterLabels:
-      VPCCIDR:
-        default: VPC CIDR
-      VPCID:
-        default: VPC ID
-      DHCPOptionSet:
-        default: Create a DHCP Options set
-      PrivateSubnet1ID:
-        default: Subnet 1 ID
-      PrivateSubnet2ID:
-        default: Subnet 2 ID
       ADServer1InstanceType:
         default: Domain Controller 1 Instance Type
       ADServer1NetBIOSName:
@@ -88,79 +75,67 @@ Metadata:
         default: Domain Controller 2 NetBIOS Name
       ADServer2PrivateIP:
         default: Domain Controller 2 Private IP Address
-      DataDriveSizeGiB:
-        default: SYSVOL and NTDS and Data Drive Size
-      KeyPairName:
-        default: Key Pair Name
-      WINFULLBASE:
-        default: SSM Parameter Value for Lastest AMI ID
-      DomainAdminUser:
-        default: Alternate Domain Admin User Name
-      DomainAdminPassword:
-        default: Alternate Domain Admin Password
-      DomainDNSName:
-        default: Domain DNS Name
-      DomainNetBIOSName:
-        default: Domain NetBIOS Name
-      CreateDefaultOUs:
-        default: Create Default OUs
-      TombstoneLifetime:
-        default: Set new Tombstone Lifetime
-      DeletedObjectLifetime:
-        default: Set new Deleted Objects Lifetime
-      PKI:
-        default: CA Deployment Type
-      CaServerInstanceType:
-        default: CA Instance Type
       CaAmi:
         default: CA SSM Parameter Value for Lastest AMI ID
       CaDataDriveSizeGiB:
         default: CA Data Drive Size
-      OrCaServerNetBIOSName:
-        default: Offline Root CA NetBIOS Name (Only Used For Two Tier PKI)
-      EntCaServerNetBIOSName:
-        default: Enterprise Root or Subordinate CA NetBIOS Name
-      CaKeyLength:
-        default: CA Key Length
       CaHashAlgorithm:
         default: CA Hash Algorithm
-      OrCaValidityPeriodUnits:
-        default: Offline Root CA Certificate Validity Period in Years (Only Used For Two Tier PKI)
+      CaKeyLength:
+        default: CA Key Length
+      CaServerInstanceType:
+        default: CA Instance Type
       CaValidityPeriodUnits:
         default: Enterprise Root or Subordinate CA Certificate Validity Period in Years
-      UseS3ForCRL:
-        default: Use S3 for CA CRL Location
-      S3CRLBucketName:
-        default: CA CRL S3 Bucket Name
+      CreateDefaultOUs:
+        default: Create Default OUs
+      DHCPOptionSet:
+        default: Create a DHCP Options set
+      DataDriveSizeGiB:
+        default: SYSVOL and NTDS and Data Drive Size
+      DeletedObjectLifetime:
+        default: Set new Deleted Objects Lifetime
+      DomainAdminPassword:
+        default: Alternate Domain Admin Password
+      DomainAdminUser:
+        default: Alternate Domain Admin User Name
+      DomainDNSName:
+        default: Domain DNS Name
+      DomainNetBIOSName:
+        default: Domain NetBIOS Name
+      EntCaServerNetBIOSName:
+        default: Enterprise Root or Subordinate CA NetBIOS Name
+      KeyPairName:
+        default: Key Pair Name
+      OrCaServerNetBIOSName:
+        default: Offline Root CA NetBIOS Name (Only Used For Two Tier PKI)
+      OrCaValidityPeriodUnits:
+        default: Offline Root CA Certificate Validity Period in Years (Only Used For Two Tier PKI)
+      PKI:
+        default: CA Deployment Type
+      PrivateSubnet1ID:
+        default: Subnet 1 ID
+      PrivateSubnet2ID:
+        default: Subnet 2 ID
       QSS3BucketName:
         default: Quick Start S3 Bucket Name
       QSS3BucketRegion:
         default: Quick Start S3 Bucket Region
       QSS3KeyPrefix:
         default: Quick Start S3 Key Prefix
+      S3CRLBucketName:
+        default: CA CRL S3 Bucket Name
+      TombstoneLifetime:
+        default: Set new Tombstone Lifetime
+      UseS3ForCRL:
+        default: Use S3 for CA CRL Location
+      VPCCIDR:
+        default: VPC CIDR
+      VPCID:
+        default: VPC ID
+      WINFULLBASE:
+        default: SSM Parameter Value for Lastest AMI ID
 Parameters:
-  VPCCIDR:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
-    Default: 10.0.0.0/16
-    Description: CIDR Block for the VPC
-    Type: String
-  VPCID:
-    Description: ID of the VPC (e.g., vpc-0343606e)
-    Type: AWS::EC2::VPC::Id
-  DHCPOptionSet:
-    AllowedValues:
-      - 'Yes'
-      - 'No'
-    Default: 'Yes'
-    Description: Do you want to create and apply a new DHCP Options Set
-    Type: String
-  PrivateSubnet1ID:
-    Description: ID of subnet 1 in Availability Zone 1 (e.g., subnet-a0246dcd)
-    Type: AWS::EC2::Subnet::Id
-  PrivateSubnet2ID:
-    Description: ID of subnet 2 in Availability Zone 2 (e.g., subnet-a0246dcd)
-    Type: AWS::EC2::Subnet::Id
   ADServer1InstanceType:
     AllowedValues:
       - t2.medium
@@ -219,29 +194,81 @@ Parameters:
     Default: 10.0.32.10
     Description: Fixed private IP for the second Active Directory Domain Controller located in Availability Zone 2
     Type: String
+  CaAmi:
+    Default: /aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base
+    Description: Enterprise Root CA SSM Parameter Value to grab the lastest AMI ID
+    Type: String
+  CaDataDriveSizeGiB:
+    Default: '2'
+    Description: Size of the data drive in GiB for the CA instance(s)
+    Type: Number
+  CaHashAlgorithm:
+    AllowedValues:
+      - SHA256
+      - SHA384
+      - SHA512
+    Default: SHA256
+    Description: CA(s) Hash Algorithm for Siging Certificates
+    Type: String
+  CaKeyLength:
+    AllowedValues:
+      - '2048'
+      - '4096'
+    Default: '2048'
+    Description: CA(s) Cryptographic Provider Key Length
+    Type: String
+  CaServerInstanceType:
+    AllowedValues:
+      - t2.small
+      - t3.small
+      - t2.medium
+      - t3.medium
+      - t2.large
+      - t3.large
+    Default: t3.medium
+    Description: Amazon EC2 instance type for the CA instance(s)
+    Type: String
+  CaValidityPeriodUnits:
+    Default: '5'
+    Description: Validity Period in Years
+    Type: String
+  CreateDefaultOUs:
+    AllowedValues:
+      - 'Yes'
+      - 'No'
+    Default: 'No'
+    Description:
+      Domain Elevated Accounts, Domain Users, Domain Computers, Domain Servers, Domain Service Accounts, and Domain Groups OUs and set the default
+      users and computers containers to Domain Users and Domain Computers
+    Type: String
+  DHCPOptionSet:
+    AllowedValues:
+      - 'Yes'
+      - 'No'
+    Default: 'Yes'
+    Description: Do you want to create and apply a new DHCP Options Set
+    Type: String
   DataDriveSizeGiB:
     Default: '10'
     Description: Size of SYSVOL and NTDS data drive in GiB
-    Type: 'Number'
-  KeyPairName:
-    Description: Public/private key pairs allow you to securely connect to your instance after it launches
-    Type: AWS::EC2::KeyPair::KeyName
-  WINFULLBASE:
-    Default: '/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base'
-    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
-  DomainAdminUser:
-    AllowedPattern: '[a-zA-Z0-9]*'
-    Default: Admin
-    Description: User name for the account that will be added as a Domain Administrator. This is separate from the default "Administrator" account
-    MaxLength: '25'
-    MinLength: '5'
-    Type: String
+    Type: Number
+  DeletedObjectLifetime:
+    Default: '180'
+    Description: The number of days before a deleted object is removed from the Active Directory recycling bin, minimum number is 2
+    Type: Number
   DomainAdminPassword:
     AllowedPattern: (?=^.{6,255}$)((?=.*\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*
     Description: Password for the account named above. Must be at least 8 characters containing letters, numbers and symbols
     MaxLength: '32'
     MinLength: '8'
     NoEcho: 'true'
+    Type: String
+  DomainAdminUser:
+    AllowedPattern: '[a-zA-Z0-9]*'
+    Default: Admin
+    Description: User name for the account that will be added as a Domain Administrator. This is separate from the default "Administrator" account
+    MaxLength: '25'
+    MinLength: '5'
     Type: String
   DomainDNSName:
     AllowedPattern: '[a-zA-Z0-9\-]+\..+'
@@ -257,55 +284,6 @@ Parameters:
     MaxLength: '15'
     MinLength: '1'
     Type: String
-  CreateDefaultOUs:
-    AllowedValues:
-      - 'Yes'
-      - 'No'
-    Default: 'No'
-    Description: Domain Elevated Accounts, Domain Users, Domain Computers, Domain Servers, Domain Service Accounts, and Domain Groups OUs and set the default users and computers containers to Domain Users and Domain Computers
-    Type: String
-  TombstoneLifetime:
-    Default: '180'
-    Description: The number of days before a deleted object is removed from Active Directory, minimum number is 2
-    Type: 'Number'
-  DeletedObjectLifetime:
-    Default: '180'
-    Description: The number of days before a deleted object is removed from the Active Directory recycling bin, minimum number is 2
-    Type: 'Number'
-  PKI:
-    AllowedValues:
-      - 'One-Tier'
-      - 'Two-Tier'
-      - 'No'
-    Default: 'No'
-    Description: Deploy Two Tier (Offline Root with Subordinate Enterprise CA) or One Tier (Enterprise Root CA) PKI Infrastructure
-    Type: String
-  CaServerInstanceType:
-    AllowedValues:
-      - t2.small
-      - t3.small
-      - t2.medium
-      - t3.medium
-      - t2.large
-      - t3.large
-    Default: t3.medium
-    Description: Amazon EC2 instance type for the CA instance(s)
-    Type: String
-  CaAmi:
-    Description: Enterprise Root CA SSM Parameter Value to grab the lastest AMI ID
-    Default: '/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base'
-    Type: String
-  CaDataDriveSizeGiB:
-    Default: '2'
-    Description: Size of the data drive in GiB for the CA instance(s)
-    Type: 'Number'
-  OrCaServerNetBIOSName:
-    AllowedPattern: '[a-zA-Z0-9\-]+'
-    Default: ORCA1
-    Description: NetBIOS name of the Offline Root CA server (Only Used For Two Tier PKI) (up to 15 characters)
-    MaxLength: '15'
-    MinLength: '1'
-    Type: String
   EntCaServerNetBIOSName:
     AllowedPattern: '[a-zA-Z0-9\-]+'
     Default: ENTCA1
@@ -313,47 +291,42 @@ Parameters:
     MaxLength: '15'
     MinLength: '1'
     Type: String
-  CaKeyLength:
-    Description: CA(s) Cryptographic Provider Key Length
-    AllowedValues:
-      - '2048'
-      - '4096'
-    Default: '2048'
-    Type: String
-  CaHashAlgorithm:
-    Description: CA(s) Hash Algorithm for Siging Certificates
-    AllowedValues:
-      - 'SHA256'
-      - 'SHA384'
-      - 'SHA512'
-    Default: 'SHA256'
+  KeyPairName:
+    Description: Public/private key pairs allow you to securely connect to your instance after it launches
+    Type: AWS::EC2::KeyPair::KeyName
+  OrCaServerNetBIOSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+'
+    Default: ORCA1
+    Description: NetBIOS name of the Offline Root CA server (Only Used For Two Tier PKI) (up to 15 characters)
+    MaxLength: '15'
+    MinLength: '1'
     Type: String
   OrCaValidityPeriodUnits:
-    Description: Validity Period in Years (Only Used For Two Tier PKI)
     Default: '10'
+    Description: Validity Period in Years (Only Used For Two Tier PKI)
     Type: String
-  CaValidityPeriodUnits:
-    Description: Validity Period in Years
-    Default: '5'
-    Type: String
-  UseS3ForCRL:
-    Description: Store CA CRL(s) in an S3 bucket
+  PKI:
     AllowedValues:
-      - 'Yes'
+      - One-Tier
+      - Two-Tier
       - 'No'
     Default: 'No'
+    Description: Deploy Two Tier (Offline Root with Subordinate Enterprise CA) or One Tier (Enterprise Root CA) PKI Infrastructure
     Type: String
-  S3CRLBucketName:
-    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
-    Default: examplebucket
-    Description: S3 bucket name for CA CRL(s) storage. Bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)
-    Type: String
+  PrivateSubnet1ID:
+    Description: ID of subnet 1 in Availability Zone 1 (e.g., subnet-a0246dcd)
+    Type: AWS::EC2::Subnet::Id
+  PrivateSubnet2ID:
+    Description: ID of subnet 2 in Availability Zone 2 (e.g., subnet-a0246dcd)
+    Type: AWS::EC2::Subnet::Id
   QSS3BucketName:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
-    ConstraintDescription: Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen
-      (-).
+    ConstraintDescription:
+      Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
     Default: aws-quickstart
-    Description: S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
+    Description:
+      S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-).
+      It cannot start or end with a hyphen (-).
     Type: String
   QSS3BucketRegion:
     Default: us-east-1
@@ -363,8 +336,40 @@ Parameters:
     AllowedPattern: ^[0-9a-zA-Z-/]*$
     ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)
     Default: quickstart-microsoft-activedirectory/
-    Description: S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)
+    Description:
+      S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and
+      forward slash (/)
     Type: String
+  S3CRLBucketName:
+    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
+    Default: examplebucket
+    Description:
+      S3 bucket name for CA CRL(s) storage. Bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or
+      end with a hyphen (-)
+    Type: String
+  TombstoneLifetime:
+    Default: '180'
+    Description: The number of days before a deleted object is removed from Active Directory, minimum number is 2
+    Type: Number
+  UseS3ForCRL:
+    AllowedValues:
+      - 'Yes'
+      - 'No'
+    Default: 'No'
+    Description: Store CA CRL(s) in an S3 bucket
+    Type: String
+  VPCCIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.0.0/16
+    Description: CIDR Block for the VPC
+    Type: String
+  VPCID:
+    Description: ID of the VPC (e.g., vpc-0343606e)
+    Type: AWS::EC2::VPC::Id
+  WINFULLBASE:
+    Default: /aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
 Rules:
   SubnetsInVPC:
     Assertions:
@@ -396,28 +401,23 @@ Rules:
         AssertDescription: M4 instances are not available in the Paris region
   S3CRLBucketNameValidation:
     RuleCondition: !And
-      - !Equals
-        - !Ref UseS3ForCRL
-        - 'Yes'
-      - !Not 
-        - !Equals
-          - !Ref PKI
-          - 'No'
+      - !Equals [!Ref UseS3ForCRL, 'Yes']
+      - !Not [!Equals [!Ref PKI, 'No']]
     Assertions:
       - AssertDescription: CRL BucketName cannot must be valid BucketName
         Assert: !Not [!Equals [!Ref S3CRLBucketName, 'examplebucket']]
 Conditions:
-  UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
+  ShouldCreateDHCPOption: !Not [!Equals [!Ref DHCPOptionSet, 'No']]
   ShouldCreateOneTierPkiResource: !Equals [!Ref PKI, 'One-Tier']
   ShouldCreateTwoTierPkiResource: !Equals [!Ref PKI, 'Two-Tier']
-  ShouldCreateDHCPOption: !Not [!Equals [!Ref DHCPOptionSet, 'No']]
+  UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
 Resources:
   DHCPOptions:
-    Type: AWS::EC2::DHCPOptions
+    Condition: ShouldCreateDHCPOption
     DependsOn:
       - DomainController1
       - DomainController2
-    Condition: ShouldCreateDHCPOption
+    Type: AWS::EC2::DHCPOptions
     Properties:
       DomainName: !Ref 'DomainDNSName'
       DomainNameServers:
@@ -427,61 +427,67 @@ Resources:
         - Key: Domain
           Value: !Ref 'DomainDNSName'
   VPCDHCPOptionsAssociation:
+    Condition: ShouldCreateDHCPOption
     Type: AWS::EC2::VPCDHCPOptionsAssociation
     Properties:
       VpcId: !Ref 'VPCID'
       DhcpOptionsId: !Ref 'DHCPOptions'
-    Condition: ShouldCreateDHCPOption
   AWSQuickstartActiveDirectoryDS:
     Type: AWS::SSM::Document
     Properties:
       DocumentType: Automation
+      Tags:
+        - Key: StackName
+          Value: !Ref AWS::StackName
       Content:
-        schemaVersion: "0.3"
-        description: "Deploy AD with SSM Automation"
+        schemaVersion: '0.3'
+        description: 'Deploy AD with SSM Automation'
         # Gathering parameters needed to configure DCs in the Quick Start
         parameters:
           VPCCIDR:
             default: '10.0.0.0/16'
-            description: "CIDR Block for the VPC"
-            type: "String"
+            description: 'CIDR Block for the VPC'
+            type: 'String'
           ADServer1NetBIOSName:
-            default: "DC1"
-            description: "NetBIOS name of the first Active Directory Domain Controller (up to 15 characters)"
-            type: "String"
+            default: 'DC1'
+            description: 'NetBIOS name of the first Active Directory Domain Controller (up to 15 characters)'
+            type: 'String'
           ADServer1PrivateIP:
-            default: "10.0.0.10"
-            description: "Fixed private IP for the first Active Directory Domain Controller located in Availability Zone 1"
-            type: "String"
+            default: '10.0.0.10'
+            description: 'Fixed private IP for the first Active Directory Domain Controller located in Availability Zone 1'
+            type: 'String'
           ADServer2NetBIOSName:
-            default: "DC2"
-            description: "NetBIOS name of the second Active Directory Domain Controller (up to 15 characters)"
-            type: "String"
+            default: 'DC2'
+            description: 'NetBIOS name of the second Active Directory Domain Controller (up to 15 characters)'
+            type: 'String'
           ADServer2PrivateIP:
-            default: "10.0.32.10"
-            description: "Fixed private IP for the second Active Directory Domain Controller located in Availability Zone 2"
-            type: "String"
+            default: '10.0.32.10'
+            description: 'Fixed private IP for the second Active Directory Domain Controller located in Availability Zone 2'
+            type: 'String'
           ADAdminSecParamName:
-            description: "AWS Secrets Parameter Name that has Password and User namer for the built-in administrator"
-            type: "String"
+            description: 'AWS Secrets Parameter Name that has Password and User namer for the built-in administrator'
+            type: 'String'
           ADAltUserSecParamName:
-            description: "AWS Secrets Parameter Name for the account that will be added as Domain Administrator. This is separate from the built-in Administrator account"
-            type: "String"
+            description:
+              'AWS Secrets Parameter Name for the account that will be added as Domain Administrator. This is separate from the built-in Administrator
+              account'
+            type: 'String'
           RestoreModeSecParamName:
-            description: "AWS Secrets Parameter Name for the Active Directory Restore Mode Password"
-            type: "String"
-          DomainDNSName: 
-            default: "example.com"
-            description: "Fully qualified domain name (FQDN) of the forest root domain e.g. example.com"
-            type: "String"
-          DomainNetBIOSName: 
-            default: "example"
-            description: "NetBIOS name of the domain (up to 15 characters) for users of earlier versions of Windows e.g. EXAMPLE"
-            type: "String"
+            description: 'AWS Secrets Parameter Name for the Active Directory Restore Mode Password'
+            type: 'String'
+          DomainDNSName:
+            default: 'example.com'
+            description: 'Fully qualified domain name (FQDN) of the forest root domain e.g. example.com'
+            type: 'String'
+          DomainNetBIOSName:
+            default: 'example'
+            description: 'NetBIOS name of the domain (up to 15 characters) for users of earlier versions of Windows e.g. EXAMPLE'
+            type: 'String'
           CreateDefaultOUs:
-            default: "No"
-            description: "Create Domain Elevated Accounts, Domain Users, Domain Computers, Domain Servers, Domain Service Accounts, and Domain Groups OUs"
-            type: "String"
+            default: 'No'
+            description:
+              'Create Domain Elevated Accounts, Domain Users, Domain Computers, Domain Servers, Domain Service Accounts, and Domain Groups OUs'
+            type: 'String'
           TombstoneLifetime:
             default: '180'
             description: The number of days before a deleted object is removed from the directory services
@@ -491,333 +497,307 @@ Resources:
             description: The number of days before a deleted object is removed from the directory services recycling bin
             type: 'String'
           QSS3BucketName:
-            default: "aws-quickstart"
-            description: "S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)"
-            type: "String"
+            default: 'aws-quickstart'
+            description:
+              'S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and
+              hyphens (-). It cannot start or end with a hyphen (-)'
+            type: 'String'
           QSS3BucketRegion:
-            default: "us-east-1"
-            description: "The AWS Region where the Quick Start S3 bucket (QSS3BucketName) is hosted. When using your own bucket, you must specify this value"
-            type: "String"
+            default: 'us-east-1'
+            description:
+              'The AWS Region where the Quick Start S3 bucket (QSS3BucketName) is hosted. When using your own bucket, you must specify this value'
+            type: 'String'
           QSS3KeyPrefix:
-            default: "quickstart-microsoft-activedirectory/"
-            description: "S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)"
-            type: "String"
+            default: 'quickstart-microsoft-activedirectory/'
+            description:
+              'S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens
+              (-), and forward slash (/)'
+            type: 'String'
           StackName:
-            default: ""
-            description: "Stack Name Input for cfn resource signal"
-            type: "String"
+            default: ''
+            description: 'Stack Name Input for cfn resource signal'
+            type: 'String'
           URLSuffix:
-            default: "amazonaws.com"
-            description: "AWS URL suffix"
-            type: "String"
+            default: 'amazonaws.com'
+            description: 'AWS URL suffix'
+            type: 'String'
         mainSteps:
-        # This step grabs the Instance IDs for both nodes that will be configured as DCs in the Quick Start and Instance IDs for the for next steps.
-        - name: "dcsInstanceIds"
-          action: aws:executeAwsApi
-          onFailure: "step:signalfailure"
-          nextStep: "dcsInstallDscModules"
-          inputs:
-            Service: ec2
-            Api: DescribeInstances
-            Filters:  
-            - Name: "tag:Name"
-              Values: [ "{{ADServer1NetBIOSName}}","{{ADServer2NetBIOSName}}" ]
-            - Name: "tag:aws:cloudformation:stack-name"
-              Values: ["{{StackName}}"]
-            - Name: "instance-state-name"
-              Values: [ "running" ]
-          outputs:
-          - Name: InstanceIds
-            Selector: "$.Reservations..Instances..InstanceId"
-            Type: "StringList"
-        # Installs needed Powershell DSC Modules and components on both nodes.
-        - name: "dcsInstallDscModules"
-          action: "aws:runCommand"
-          onFailure: "step:signalfailure"
-          nextStep: "dcsLCMConfig"
-          inputs:
-            DocumentName: "AWS-RunRemoteScript"
-            InstanceIds:
-            - "{{dcsInstanceIds.InstanceIds}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              sourceType: "S3"
-              sourceInfo: 
-                !Sub 
+          # This step grabs the Instance IDs for both nodes that will be configured as DCs in the Quick Start and Instance IDs for the for next steps.
+          - name: 'dcsInstanceIds'
+            action: aws:executeAwsApi
+            onFailure: 'step:signalfailure'
+            nextStep: 'dcsInstallDscModules'
+            inputs:
+              Service: ec2
+              Api: DescribeInstances
+              Filters:
+                - Name: 'tag:Name'
+                  Values: ['{{ADServer1NetBIOSName}}', '{{ADServer2NetBIOSName}}']
+                - Name: 'tag:aws:cloudformation:stack-name'
+                  Values: ['{{StackName}}']
+                - Name: 'instance-state-name'
+                  Values: ['running']
+            outputs:
+              - Name: InstanceIds
+                Selector: '$.Reservations..Instances..InstanceId'
+                Type: 'StringList'
+          # Installs needed Powershell DSC Modules and components on both nodes.
+          - name: 'dcsInstallDscModules'
+            action: 'aws:runCommand'
+            onFailure: 'step:signalfailure'
+            nextStep: 'dcsLCMConfig'
+            inputs:
+              DocumentName: 'AWS-RunRemoteScript'
+              InstanceIds:
+                - '{{dcsInstanceIds.InstanceIds}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                sourceType: 'S3'
+                sourceInfo: !Sub
                   - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/install-ad-modules.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If 
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: "./install-ad-modules.ps1"
-        # Configures Local Configuration Manager on each of the nodes.
-        - name: "dcsLCMConfig"
-          action: "aws:runCommand"
-          onFailure: "step:signalfailure"
-          nextStep: "dc1InstanceId"
-          inputs:
-            DocumentName: "AWS-RunRemoteScript"
-            InstanceIds:
-            - "{{dcsInstanceIds.InstanceIds}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              sourceType: "S3"
-              sourceInfo: 
-                !Sub 
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+                    S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+                commandLine: './install-ad-modules.ps1'
+          # Configures Local Configuration Manager on each of the nodes.
+          - name: 'dcsLCMConfig'
+            action: 'aws:runCommand'
+            onFailure: 'step:signalfailure'
+            nextStep: 'dc1InstanceId'
+            inputs:
+              DocumentName: 'AWS-RunRemoteScript'
+              InstanceIds:
+                - '{{dcsInstanceIds.InstanceIds}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                sourceType: 'S3'
+                sourceInfo: !Sub
                   - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/LCM-Config.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If 
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: "./LCM-Config.ps1"
-        # This step grabs the Instance ID for the node that will be configured as the first DC in the new domain.
-        - name: "dc1InstanceId"
-          action: aws:executeAwsApi
-          onFailure: "step:signalfailure"
-          nextStep: "createDC1Mof"
-          inputs:
-            Service: ec2
-            Api: DescribeInstances
-            Filters:  
-            - Name: "tag:Name"
-              Values: [ "{{ADServer1NetBIOSName}}" ]
-            - Name: "tag:aws:cloudformation:stack-name"
-              Values: ["{{StackName}}"]
-            - Name: "instance-state-name"
-              Values: [ "running" ]
-          outputs:
-          - Name: InstanceId
-            Selector: "$.Reservations[0].Instances[0].InstanceId"
-            Type: "String"
-        # Generates MOF file on first DC Node to be processed by LCM.
-        - name: "createDC1Mof"
-          action: "aws:runCommand"
-          onFailure: "step:signalfailure"
-          nextStep: "configDC1"
-          inputs:
-            DocumentName: "AWS-RunRemoteScript"
-            InstanceIds:
-            - "{{dc1InstanceId.InstanceId}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              sourceType: "S3"
-              sourceInfo: 
-                !Sub
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+                    S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+                commandLine: './LCM-Config.ps1'
+          # This step grabs the Instance ID for the node that will be configured as the first DC in the new domain.
+          - name: 'dc1InstanceId'
+            action: aws:executeAwsApi
+            onFailure: 'step:signalfailure'
+            nextStep: 'createDC1Mof'
+            inputs:
+              Service: ec2
+              Api: DescribeInstances
+              Filters:
+                - Name: 'tag:Name'
+                  Values: ['{{ADServer1NetBIOSName}}']
+                - Name: 'tag:aws:cloudformation:stack-name'
+                  Values: ['{{StackName}}']
+                - Name: 'instance-state-name'
+                  Values: ['running']
+            outputs:
+              - Name: InstanceId
+                Selector: '$.Reservations[0].Instances[0].InstanceId'
+                Type: 'String'
+          # Generates MOF file on first DC Node to be processed by LCM.
+          - name: 'createDC1Mof'
+            action: 'aws:runCommand'
+            onFailure: 'step:signalfailure'
+            nextStep: 'configDC1'
+            inputs:
+              DocumentName: 'AWS-RunRemoteScript'
+              InstanceIds:
+                - '{{dc1InstanceId.InstanceId}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                sourceType: 'S3'
+                sourceInfo: !Sub
                   - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/ConfigDC1.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If 
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: "./ConfigDC1.ps1 -ADServer1NetBIOSName {{ADServer1NetBIOSName}} -DomainNetBIOSName {{DomainNetBIOSName}} -DomainDNSName {{DomainDNSName}} -ADAdminSecParam {{ADAdminSecParamName}} -ADAltUserSecParam {{ADAltUserSecParamName}} -RestoreModeSecParam {{RestoreModeSecParamName}} -SiteName {{global:REGION}} -VPCCIDR {{VPCCIDR}}"
-        # Kicks off DSC Configuration and loops\reboots until Node matches Configuration defined in MOF file.
-        - name: "configDC1"
-          action: aws:runCommand
-          onFailure: "step:signalfailure"
-          nextStep: "dc2InstanceId"
-          inputs:
-            DocumentName: AWS-RunPowerShellScript
-            InstanceIds: 
-              - "{{dc1InstanceId.InstanceId}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              commands: 
-                - |     
-                   function DscStatusCheck () {
-                       $LCMState = (Get-DscLocalConfigurationManager).LCMState
-                       if ($LCMState -eq 'PendingConfiguration' -Or $LCMState -eq 'PendingReboot') {
-                           'returning 3010, should continue after reboot'
-                           exit 3010
-                       } else {
-                           'Completed'
-                       }
-                   }
-                   
-                   Start-DscConfiguration 'C:\AWSQuickstart\ConfigDC1' -Wait -Verbose -Force
-                   
-                   DscStatusCheck
-        # This step grabs the Instance ID for the node that will be configured as the second DC in the new domain.
-        - name: "dc2InstanceId"
-          action: aws:executeAwsApi
-          onFailure: "step:signalfailure"
-          nextStep: "createDC2Mof"
-          inputs:
-            Service: ec2
-            Api: DescribeInstances
-            Filters:  
-            - Name: "tag:Name"
-              Values: [ "{{ADServer2NetBIOSName}}" ]
-            - Name: "tag:aws:cloudformation:stack-name"
-              Values: ["{{StackName}}"]
-            - Name: "instance-state-name"
-              Values: [ "running" ]
-          outputs:
-          - Name: InstanceId
-            Selector: "$.Reservations[0].Instances[0].InstanceId"
-            Type: "String"
-        # Generates MOF file on second DC Node to be processed by LCM.
-        - name: "createDC2Mof"
-          action: "aws:runCommand"
-          onFailure: "step:signalfailure"
-          nextStep: "configDC2"
-          inputs:
-            DocumentName: "AWS-RunRemoteScript"
-            InstanceIds:
-            - "{{dc2InstanceId.InstanceId}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              sourceType: "S3"
-              sourceInfo: 
-                !Sub
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+                    S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+                commandLine:
+                  './ConfigDC1.ps1 -ADServer1NetBIOSName {{ADServer1NetBIOSName}} -DomainNetBIOSName {{DomainNetBIOSName}} -DomainDNSName
+                  {{DomainDNSName}} -ADAdminSecParam {{ADAdminSecParamName}} -ADAltUserSecParam {{ADAltUserSecParamName}} -RestoreModeSecParam
+                  {{RestoreModeSecParamName}} -SiteName {{global:REGION}} -VPCCIDR {{VPCCIDR}}'
+          # Kicks off DSC Configuration and loops\reboots until Node matches Configuration defined in MOF file.
+          - name: 'configDC1'
+            action: aws:runCommand
+            onFailure: 'step:signalfailure'
+            nextStep: 'dc2InstanceId'
+            inputs:
+              DocumentName: AWS-RunPowerShellScript
+              InstanceIds:
+                - '{{dc1InstanceId.InstanceId}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                commands:
+                  - |
+                    function DscStatusCheck () {
+                        $LCMState = (Get-DscLocalConfigurationManager).LCMState
+                        if ($LCMState -eq 'PendingConfiguration' -Or $LCMState -eq 'PendingReboot') {
+                            'returning 3010, should continue after reboot'
+                            exit 3010
+                        } else {
+                            'Completed'
+                        }
+                    }
+
+                    Start-DscConfiguration 'C:\AWSQuickstart\ConfigDC1' -Wait -Verbose -Force
+
+                    DscStatusCheck
+          # This step grabs the Instance ID for the node that will be configured as the second DC in the new domain.
+          - name: 'dc2InstanceId'
+            action: aws:executeAwsApi
+            onFailure: 'step:signalfailure'
+            nextStep: 'createDC2Mof'
+            inputs:
+              Service: ec2
+              Api: DescribeInstances
+              Filters:
+                - Name: 'tag:Name'
+                  Values: ['{{ADServer2NetBIOSName}}']
+                - Name: 'tag:aws:cloudformation:stack-name'
+                  Values: ['{{StackName}}']
+                - Name: 'instance-state-name'
+                  Values: ['running']
+            outputs:
+              - Name: InstanceId
+                Selector: '$.Reservations[0].Instances[0].InstanceId'
+                Type: 'String'
+          # Generates MOF file on second DC Node to be processed by LCM.
+          - name: 'createDC2Mof'
+            action: 'aws:runCommand'
+            onFailure: 'step:signalfailure'
+            nextStep: 'configDC2'
+            inputs:
+              DocumentName: 'AWS-RunRemoteScript'
+              InstanceIds:
+                - '{{dc2InstanceId.InstanceId}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                sourceType: 'S3'
+                sourceInfo: !Sub
                   - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/ConfigDC2.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If 
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: "./ConfigDC2.ps1 -ADServer2NetBIOSName {{ADServer2NetBIOSName}} -DomainNetBIOSName {{DomainNetBIOSName}} -DomainDNSName {{DomainDNSName}} -ADServer1PrivateIP {{ADServer1PrivateIP}} -ADAdminSecParam {{ADAdminSecParamName}} -RestoreModeSecParam {{RestoreModeSecParamName}} "
-        # Kicks off DSC Configuration and loops\reboots until Node matches Configuration defined in MOF file.
-        - name: "configDC2"
-          action: aws:runCommand
-          onFailure: "step:signalfailure"
-          nextStep: "DnsConfig"
-          inputs:
-            DocumentName: AWS-RunPowerShellScript
-            InstanceIds: 
-              - "{{dc2InstanceId.InstanceId}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              commands: 
-                - |     
-                   function DscStatusCheck () {
-                       $LCMState = (Get-DscLocalConfigurationManager).LCMState
-                       if ($LCMState -eq 'PendingConfiguration' -Or $LCMState -eq 'PendingReboot') {
-                           'returning 3010, should continue after reboot'
-                           exit 3010
-                       } else {
-                           'Completed'
-                       }
-                   }
-                   
-                   Start-DscConfiguration 'C:\AWSQuickstart\ConfigDC2' -Wait -Verbose -Force
-                   
-                   DscStatusCheck
-        # Ensure that AD servers point to themselves for DNS
-        - name: "DnsConfig"
-          action: "aws:runCommand"
-          onFailure: "step:signalfailure"
-          nextStep: "PostConfig"
-          inputs:
-            DocumentName: "AWS-RunRemoteScript"
-            InstanceIds:
-              - "{{dc2InstanceId.InstanceId}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              sourceType: S3
-              sourceInfo: 
-                !Sub 
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+                    S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+                commandLine:
+                  './ConfigDC2.ps1 -ADServer2NetBIOSName {{ADServer2NetBIOSName}} -DomainNetBIOSName {{DomainNetBIOSName}} -DomainDNSName
+                  {{DomainDNSName}} -ADServer1PrivateIP {{ADServer1PrivateIP}} -ADAdminSecParam {{ADAdminSecParamName}} -RestoreModeSecParam
+                  {{RestoreModeSecParamName}} '
+          # Kicks off DSC Configuration and loops\reboots until Node matches Configuration defined in MOF file.
+          - name: 'configDC2'
+            action: aws:runCommand
+            onFailure: 'step:signalfailure'
+            nextStep: 'DnsConfig'
+            inputs:
+              DocumentName: AWS-RunPowerShellScript
+              InstanceIds:
+                - '{{dc2InstanceId.InstanceId}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                commands:
+                  - |
+                    function DscStatusCheck () {
+                        $LCMState = (Get-DscLocalConfigurationManager).LCMState
+                        if ($LCMState -eq 'PendingConfiguration' -Or $LCMState -eq 'PendingReboot') {
+                            'returning 3010, should continue after reboot'
+                            exit 3010
+                        } else {
+                            'Completed'
+                        }
+                    }
+
+                    Start-DscConfiguration 'C:\AWSQuickstart\ConfigDC2' -Wait -Verbose -Force
+
+                    DscStatusCheck
+          # Ensure that AD servers point to themselves for DNS
+          - name: 'DnsConfig'
+            action: 'aws:runCommand'
+            onFailure: 'step:signalfailure'
+            nextStep: 'PostConfig'
+            inputs:
+              DocumentName: 'AWS-RunRemoteScript'
+              InstanceIds:
+                - '{{dc2InstanceId.InstanceId}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                sourceType: S3
+                sourceInfo: !Sub
                   - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Dns-Config.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If 
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: "./Dns-Config.ps1 -ADServer1NetBIOSName {{ADServer1NetBIOSName}} -ADServer2NetBIOSName {{ADServer2NetBIOSName}} -ADServer1PrivateIP {{ADServer1PrivateIP}} -ADServer2PrivateIP {{ADServer2PrivateIP}} -DomainDNSName {{DomainDNSName}} -ADAdminSecParam {{ADAdminSecParamName}}"
-        # Cleanup and finalize setup
-        - name: "PostConfig"
-          action: "aws:runCommand"
-          onFailure: "step:signalfailure"
-          inputs:
-            DocumentName: "AWS-RunRemoteScript"
-            InstanceIds:
-              - "{{dcsInstanceIds.InstanceIds}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              sourceType: S3
-              sourceInfo: 
-                !Sub 
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+                    S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+                commandLine:
+                  './Dns-Config.ps1 -ADServer1NetBIOSName {{ADServer1NetBIOSName}} -ADServer2NetBIOSName {{ADServer2NetBIOSName}} -ADServer1PrivateIP
+                  {{ADServer1PrivateIP}} -ADServer2PrivateIP {{ADServer2PrivateIP}} -DomainDNSName {{DomainDNSName}} -ADAdminSecParam
+                  {{ADAdminSecParamName}}'
+          # Cleanup and finalize setup
+          - name: 'PostConfig'
+            action: 'aws:runCommand'
+            onFailure: 'step:signalfailure'
+            inputs:
+              DocumentName: 'AWS-RunRemoteScript'
+              InstanceIds:
+                - '{{dcsInstanceIds.InstanceIds}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                sourceType: S3
+                sourceInfo: !Sub
                   - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Post-Config.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If 
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: "./Post-Config.ps1 -S3BucketName {{QSS3BucketName}} -S3KeyPrefix {{QSS3KeyPrefix}} -VPCCIDR {{VPCCIDR}} -CreateDefaultOUs {{CreateDefaultOUs}} -TombstoneLifetime {{TombstoneLifetime}} -DeletedObjectLifetime {{DeletedObjectLifetime}}"
-        # Determines if CFN Needs to be Signaled or if Work flow should just end
-        - name: CFNSignalEnd
-          action: aws:branch
-          inputs:
-            Choices:
-            - NextStep: signalsuccess
-              Not: 
-                Variable: "{{StackName}}"
-                StringEquals: ""
-            - NextStep: sleepend
-              Variable: "{{StackName}}"
-              StringEquals: ""
-        # If all steps complete successfully signals CFN of Success
-        - name: "signalsuccess"
-          action: "aws:executeAwsApi"
-          isEnd: True
-          inputs:
-            Service: cloudformation
-            Api: SignalResource
-            LogicalResourceId: "DomainController2"
-            StackName: "{{StackName}}"
-            Status: SUCCESS
-            UniqueId: "{{dc2InstanceId.InstanceId}}"
-        # If CFN Signl Not Needed this sleep ends work flow
-        - name: "sleepend"
-          action: "aws:sleep"
-          isEnd: True
-          inputs:
-            Duration: PT1S
-        # If any steps fails signals CFN of Failure
-        - name: "signalfailure"
-          action: "aws:executeAwsApi"
-          inputs:
-            Service: cloudformation
-            Api: SignalResource
-            LogicalResourceId: "DomainController2"
-            StackName: "{{StackName}}"
-            Status: FAILURE
-            UniqueId: "{{dc2InstanceId.InstanceId}}"
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+                    S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+                commandLine:
+                  './Post-Config.ps1 -S3BucketName {{QSS3BucketName}} -S3KeyPrefix {{QSS3KeyPrefix}} -VPCCIDR {{VPCCIDR}} -CreateDefaultOUs
+                  {{CreateDefaultOUs}} -TombstoneLifetime {{TombstoneLifetime}} -DeletedObjectLifetime {{DeletedObjectLifetime}}'
+          # Determines if CFN Needs to be Signaled or if Work flow should just end
+          - name: CFNSignalEnd
+            action: aws:branch
+            inputs:
+              Choices:
+                - NextStep: signalsuccess
+                  Not:
+                    Variable: '{{StackName}}'
+                    StringEquals: ''
+                - NextStep: sleepend
+                  Variable: '{{StackName}}'
+                  StringEquals: ''
+          # If all steps complete successfully signals CFN of Success
+          - name: 'signalsuccess'
+            action: 'aws:executeAwsApi'
+            isEnd: True
+            inputs:
+              Service: cloudformation
+              Api: SignalResource
+              LogicalResourceId: 'DomainController2'
+              StackName: '{{StackName}}'
+              Status: SUCCESS
+              UniqueId: '{{dc2InstanceId.InstanceId}}'
+          # If CFN Signl Not Needed this sleep ends work flow
+          - name: 'sleepend'
+            action: 'aws:sleep'
+            isEnd: True
+            inputs:
+              Duration: PT1S
+          # If any steps fails signals CFN of Failure
+          - name: 'signalfailure'
+            action: 'aws:executeAwsApi'
+            inputs:
+              Service: cloudformation
+              Api: SignalResource
+              LogicalResourceId: 'DomainController2'
+              StackName: '{{StackName}}'
+              Status: FAILURE
+              UniqueId: '{{dc2InstanceId.InstanceId}}'
   ADServerRole:
     Type: AWS::IAM::Role
     Properties:
@@ -825,17 +805,33 @@ Resources:
         - PolicyDocument:
             Version: '2012-10-17'
             Statement:
-              - Action:
-                  - s3:ListBucket
-                Resource: 
-                  - !Sub ['arn:${AWS::Partition}:s3:::${S3Bucket}', S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]]
-                Effect: Allow
-              - Action:
-                  - s3:GetObject
-                Resource: 
-                  - !Sub ['arn:${AWS::Partition}:s3:::${S3Bucket}/${QSS3KeyPrefix}*', S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]]
-                Effect: Allow
-              - Action:
+              - Effect: Allow
+                Action: s3:GetObject
+                Resource:
+                  - !Sub arn:aws:s3:::aws-ssm-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::aws-windows-downloads-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::amazon-ssm-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::amazon-ssm-packages-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::${AWS::Region}-birdwatcher-prod/*
+                  - !Sub arn:aws:s3:::patch-baseline-snapshot-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::aws-ssm-distributor-file-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::aws-ssm-document-attachments-${AWS::Region}/*
+          PolicyName: SSMAgent
+        - PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: s3:ListBucket
+                Resource: !Sub
+                  - 'arn:${AWS::Partition}:s3:::${S3Bucket}'
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+              - Effect: Allow
+                Action: s3:GetObject
+                Resource: !Sub
+                  - 'arn:${AWS::Partition}:s3:::${S3Bucket}/${QSS3KeyPrefix}*'
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+              - Effect: Allow
+                Action:
                   - ec2:DescribeInstances
                   - ssm:DescribeInstanceInformation
                   - ssm:ListCommands
@@ -843,11 +839,9 @@ Resources:
                   - ssm:SendCommand
                   - ssm:StartAutomationExecution
                 Resource: '*'
-                Effect: Allow
-              - Action:
-                  - cloudformation:SignalResource
+              - Effect: Allow
+                Action: cloudformation:SignalResource
                 Resource: !Sub 'arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*'
-                Effect: Allow
           PolicyName: AWS-Mgmt-Quick-Start-Policy
         - PolicyDocument:
             Version: '2012-10-17'
@@ -856,7 +850,7 @@ Resources:
                 Action:
                   - secretsmanager:GetSecretValue
                   - secretsmanager:DescribeSecret
-                Resource: 
+                Resource:
                   - !Ref 'ADAdminSecrets'
                   - !Ref 'RestoreModeSecrets'
                   - !Ref 'ADAltUserSecrets'
@@ -865,14 +859,16 @@ Resources:
       ManagedPolicyArns:
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy'
+      Tags:
+        - Key: StackName
+          Value: !Ref AWS::StackName
       AssumeRolePolicyDocument:
         Statement:
-          - Action:
-              - sts:AssumeRole
+          - Effect: Allow
+            Action: sts:AssumeRole
             Principal:
               Service:
                 - ec2.amazonaws.com
-            Effect: Allow
         Version: '2012-10-17'
   ADServerProfile:
     Type: AWS::IAM::InstanceProfile
@@ -887,7 +883,7 @@ Resources:
       Description: Administrator Password for AD Quick Start
       GenerateSecretString:
         SecretStringTemplate: '{"username": "Administrator"}'
-        GenerateStringKey: "password"
+        GenerateStringKey: 'password'
         PasswordLength: 30
         ExcludeCharacters: '"@/\'
   RestoreModeSecrets:
@@ -897,7 +893,7 @@ Resources:
       Description: Restore Mode Password for AD Quick Start
       GenerateSecretString:
         SecretStringTemplate: '{"username": "Administrator"}'
-        GenerateStringKey: "password"
+        GenerateStringKey: 'password'
         PasswordLength: 30
         ExcludeCharacters: '"@/\'
   ADAltUserSecrets:
@@ -916,26 +912,32 @@ Resources:
       Tags:
         - Key: Name
           Value: !Ref 'ADServer1NetBIOSName'
+        - Key: Domain
+          Value: !Ref 'DomainDNSName'
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeSize: 60
             VolumeType: gp3
+            Encrypted: true
+            DeleteOnTermination: true
         - DeviceName: /dev/xvdf
           Ebs:
             VolumeSize: !Ref 'DataDriveSizeGiB'
             VolumeType: gp3
+            Encrypted: true
+            DeleteOnTermination: true
       SecurityGroupIds:
         - !Ref 'DomainControllersSG'
       PrivateIpAddress: !Ref 'ADServer1PrivateIP'
       KeyName: !Ref 'KeyPairName'
   DomainController2:
-    Type: AWS::EC2::Instance
-    DependsOn: DomainController1
     CreationPolicy:
       ResourceSignal:
         Timeout: PT60M
         Count: 1
+    DependsOn: DomainController1
+    Type: AWS::EC2::Instance
     Properties:
       ImageId: !Ref 'WINFULLBASE'
       IamInstanceProfile: !Ref 'ADServerProfile'
@@ -944,15 +946,21 @@ Resources:
       Tags:
         - Key: Name
           Value: !Ref 'ADServer2NetBIOSName'
+        - Key: Domain
+          Value: !Ref 'DomainDNSName'
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeSize: 60
             VolumeType: gp3
+            Encrypted: true
+            DeleteOnTermination: true
         - DeviceName: /dev/xvdf
           Ebs:
             VolumeSize: !Ref 'DataDriveSizeGiB'
             VolumeType: gp3
+            Encrypted: true
+            DeleteOnTermination: true
       SecurityGroupIds:
         - !Ref 'DomainControllersSG'
       PrivateIpAddress: !Ref 'ADServer2PrivateIP'
@@ -1007,8 +1015,7 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Domain Controllers Security Group
-      VpcId:
-        Ref: VPCID
+      VpcId: !Ref VPCID
       SecurityGroupIngress:
         - IpProtocol: tcp
           Description: DNS
@@ -1115,56 +1122,60 @@ Resources:
           FromPort: 49152
           ToPort: 65535
           SourceSecurityGroupId: !Ref DomainMembersSG
-  DomainMembersSG: 
+      Tags:
+        - Key: Name
+          Value: DomainControllersSG
+  DomainMembersSG:
     Type: AWS::EC2::SecurityGroup
-    Properties: 
+    Properties:
       GroupDescription: Domain Members
       VpcId: !Ref VPCID
+      Tags:
+        - Key: Name
+          Value: DomainMembersSG
   DomainMembersIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      Description: RDP 
+      Description: RDP
       GroupId: !Ref DomainMembersSG
-      IpProtocol: tcp 
-      FromPort: 3389 
+      IpProtocol: tcp
+      FromPort: 3389
       ToPort: 3389
       SourceSecurityGroupId: !Ref DomainMembersSG
   DCSecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      Description: Security Group Rule between Domain Controllers 
+      Description: Security Group Rule between Domain Controllers
       GroupId: !Ref DomainControllersSG
-      IpProtocol: '-1' 
-      FromPort: -1 
-      ToPort: -1 
+      IpProtocol: '-1'
+      FromPort: -1
+      ToPort: -1
       SourceSecurityGroupId: !Ref DomainControllersSG
   EntCAStack:
-    Type: AWS::CloudFormation::Stack
-    DependsOn: DomainController2
     Condition: ShouldCreateOneTierPkiResource
+    DependsOn: DomainController2
+    Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL:
-        Fn::Sub:
-          - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-microsoft-pki/templates/microsoft-pki.template.yaml'
-          - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
-            S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+      TemplateURL: !Sub
+        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-microsoft-pki/templates/one-tier.template'
+        - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+          S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
-        AdministratorSecret: !Ref 'ADAltUserSecrets'
         AMI: !Ref 'CaAmi'
-        CADeploymentType: 'One-Tier'
-        CaHashAlgorithm: !Ref 'CaHashAlgorithm'
-        CaKeyLength: !Ref 'CaKeyLength'
-        CaServerSubnet: !Ref 'PrivateSubnet1ID'
-        CaValidityPeriodUnits: !Ref 'CaValidityPeriodUnits'
+        AdministratorSecret: !Ref 'ADAltUserSecrets'
         DirectoryType: 'SelfManaged'
         DomainController1IP: !Ref 'ADServer1PrivateIP'
         DomainController2IP: !Ref 'ADServer2PrivateIP'
-        DomainDNSName: !Ref 'DomainDNSName'     
+        DomainDNSName: !Ref 'DomainDNSName'
         DomainMembersSG: !Ref 'DomainMembersSG'
-        DomainNetBIOSName: !Ref 'DomainNetBIOSName'       
+        DomainNetBIOSName: !Ref 'DomainNetBIOSName'
         EntCaDataDriveSizeGiB: !Ref 'CaDataDriveSizeGiB'
+        EntCaHashAlgorithm: !Ref 'CaHashAlgorithm'
+        EntCaKeyLength: !Ref 'CaKeyLength'
         EntCaServerInstanceType: !Ref 'CaServerInstanceType'
         EntCaServerNetBIOSName: !Ref 'EntCaServerNetBIOSName'
+        EntCaServerSubnet: !Ref 'PrivateSubnet1ID'
+        EntCaValidityPeriodUnits: !Ref 'CaValidityPeriodUnits'
         KeyPairName: !Ref 'KeyPairName'
         QSS3BucketName: !Ref 'QSS3BucketName'
         QSS3BucketRegion: !Ref 'QSS3BucketRegion'
@@ -1174,64 +1185,61 @@ Resources:
         VPCCIDR: !Ref 'VPCCIDR'
         VPCID: !Ref 'VPCID'
   TwoTierCAStack:
-    Type: AWS::CloudFormation::Stack
-    DependsOn: DomainController2
     Condition: ShouldCreateTwoTierPkiResource
+    DependsOn: DomainController2
+    Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL:
-        Fn::Sub:
-          - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-microsoft-pki/templates/microsoft-pki.template.yaml'
-          - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
-            S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+      TemplateURL: !Sub
+        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-microsoft-pki/templates/two-tier.template'
+        - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+          S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
-        AdministratorSecret: !Ref 'ADAltUserSecrets'
         AMI: !Ref 'CaAmi'
-        CADeploymentType: 'Two-Tier'
-        CaHashAlgorithm: !Ref 'CaHashAlgorithm'
-        CaKeyLength: !Ref 'CaKeyLength'
-        CaServerSubnet: !Ref 'PrivateSubnet1ID'
-        OrCaValidityPeriodUnits: !Ref 'OrCaValidityPeriodUnits'
-        CaValidityPeriodUnits: !Ref 'CaValidityPeriodUnits'
+        AdministratorSecret: !Ref 'ADAltUserSecrets'
         DirectoryType: 'SelfManaged'
         DomainController1IP: !Ref 'ADServer1PrivateIP'
         DomainController2IP: !Ref 'ADServer2PrivateIP'
-        DomainDNSName: !Ref 'DomainDNSName'     
+        DomainDNSName: !Ref 'DomainDNSName'
         DomainMembersSG: !Ref 'DomainMembersSG'
         DomainNetBIOSName: !Ref 'DomainNetBIOSName'
-        OrCaDataDriveSizeGiB: !Ref 'CaDataDriveSizeGiB'     
-        EntCaDataDriveSizeGiB: !Ref 'CaDataDriveSizeGiB'
-        EntCaServerInstanceType: !Ref 'CaServerInstanceType'
-        OrCaServerInstanceType: !Ref 'CaServerInstanceType'
-        EntCaServerNetBIOSName: !Ref 'EntCaServerNetBIOSName'
-        OrCaServerNetBIOSName: !Ref 'OrCaServerNetBIOSName'
         KeyPairName: !Ref 'KeyPairName'
+        OrCaDataDriveSizeGiB: !Ref 'CaDataDriveSizeGiB'
+        OrCaHashAlgorithm: !Ref 'CaHashAlgorithm'
+        OrCaKeyLength: !Ref 'CaKeyLength'
+        OrCaServerInstanceType: !Ref 'CaServerInstanceType'
+        OrCaServerNetBIOSName: !Ref 'OrCaServerNetBIOSName'
+        OrCaServerSubnet: !Ref 'PrivateSubnet1ID'
+        OrCaValidityPeriodUnits: !Ref 'OrCaValidityPeriodUnits'
         QSS3BucketName: !Ref 'QSS3BucketName'
         QSS3BucketRegion: !Ref 'QSS3BucketRegion'
         QSS3KeyPrefix: !Sub '${QSS3KeyPrefix}submodules/quickstart-microsoft-pki/'
         S3CRLBucketName: !Ref 'S3CRLBucketName'
+        SubCaDataDriveSizeGiB: !Ref 'CaDataDriveSizeGiB'
+        SubCaHashAlgorithm: !Ref 'CaHashAlgorithm'
+        SubCaKeyLength: !Ref 'CaKeyLength'
+        SubCaServerInstanceType: !Ref 'CaServerInstanceType'
+        SubCaServerNetBIOSName: !Ref 'EntCaServerNetBIOSName'
+        SubCaServerSubnet: !Ref 'PrivateSubnet1ID'
+        SubCaValidityPeriodUnits: !Ref 'CaValidityPeriodUnits'
         UseS3ForCRL: !Ref 'UseS3ForCRL'
         VPCCIDR: !Ref 'VPCCIDR'
         VPCID: !Ref 'VPCID'
 Outputs:
-  DomainAdmin:
-    Value: !Join
-      - ''
-      - - !Ref 'DomainNetBIOSName'
-        - \
-        - !Ref 'DomainAdminUser'
-    Description: Domain administrator account
-  DomainMemberSGID:
-    Value: !Ref 'DomainMembersSG'
-    Description: Domain Member Security Group ID
-  DomainControllersSGID:
-    Value: !Ref 'DomainControllersSG'
-    Description: Domain Controllers Security Group ID
   ADSecretsArn:
-    Value: !Ref 'ADAltUserSecrets'
     Description: Alternate AD User Secrets ARN
+    Value: !Ref 'ADAltUserSecrets'
   DC1InstanceId:
-    Value: !Ref 'DomainController1'
     Description: DomainController 1 instance ID
+    Value: !Ref 'DomainController1'
   DC2InstanceId:
-    Value: !Ref 'DomainController2'
     Description: DomainController 2 instance ID
+    Value: !Ref 'DomainController2'
+  DomainAdmin:
+    Description: Domain administrator account
+    Value: !Sub ${DomainNetBIOSName}\${DomainAdminUser}
+  DomainControllersSGID:
+    Description: Domain Controllers Security Group ID
+    Value: !Ref 'DomainControllersSG'
+  DomainMemberSGID:
+    Description: Domain Member Security Group ID
+    Value: !Ref 'DomainMembersSG'

--- a/templates/ad-2.template
+++ b/templates/ad-2.template
@@ -1,15 +1,12 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >-
-  This template creates 2 Windows Server instances into private subnets in separate
-  Availability Zones inside a VPC. After extending your on-premises network to the
-  VPC, you can promote the Windows Server instances to Domain Controllers in your
-  AD forest. **WARNING** This template creates Amazon EC2 Windows instance and related
-  resources. You will be billed for the AWS resources used if you create a stack from
-  this template. (qs-1qup6radg)
+  This template creates 2 Windows Server instances into private subnets in separate Availability Zones inside a VPC. After extending your on-premises
+  network to the VPC, you can promote the Windows Server instances to Domain Controllers in your AD forest. **WARNING** This template creates Amazon
+  EC2 Windows instance and related resources. You will be billed for the AWS resources used if you create a stack from this template. (qs-1qup6radg)
 Metadata:
   QuickStartDocumentation:
-    EntrypointName: "Extend on-premises Active Directory into an existing VPC"
-    Order: "3"
+    EntrypointName: 'Extend on-premises Active Directory into an existing VPC'
+    Order: '3'
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
@@ -19,7 +16,6 @@ Metadata:
           - VPCID
           - Subnet1ID
           - Subnet2ID
-          - DomainControllersSG
       - Label:
           default: Amazon EC2 Configuration
         Parameters:
@@ -48,18 +44,6 @@ Metadata:
           - QSS3BucketRegion
           - QSS3KeyPrefix
     ParameterLabels:
-      VPCCIDR:
-        default: VPC CIDR
-      VPCID:
-        default: VPC ID
-      Subnet1ID:
-        default: Subnet 1 ID
-      Subnet2ID:
-        default: Subnet 2 ID
-      DomainControllersSG:
-        default: Security Group ID for Domain Members Security Group
-      ADServerInstanceType:
-        default: Domain Controllers Instance Type
       ADServer1NetBIOSName:
         default: Domain Controller 1 NetBIOS Name
       ADServer1PrivateIP:
@@ -68,68 +52,43 @@ Metadata:
         default: Domain Controller 2 NetBIOS Name
       ADServer2PrivateIP:
         default: Domain Controller 2 Private IP Address
-      DataDriveSizeGiB:
-        default: SYSVOL and NTDS and Data Drive Size
-      KeyPairName:
-        default: Key Pair Name
-      LatestAmiId:
-        default: SSM Parameter Value for lastest AMI ID
-      JoinAndPromote:
-        default: Join and Promote to Domain Controllers
+      ADServerInstanceType:
+        default: Domain Controllers Instance Type
       AdministratorSecret:
         default: Secret ARN Containing Administrator Credentials
-      RestoreModeSecret:
-        default: Secret ARN Containing Restore Mode Credentials
-      ExistingDomainController1IP:
-        default: IP the Instance will be used for DNS (Must be accessible)
-      ExistingDomainController2IP:
-        default: IP the Instance will be used for DNS (Must be accessible)
+      DataDriveSizeGiB:
+        default: SYSVOL and NTDS and Data Drive Size
       DomainDNSName:
         default: Domain DNS Name
       DomainNetBIOSName:
         default: Domain NetBIOS Name
+      ExistingDomainController1IP:
+        default: IP the Instance will be used for DNS (Must be accessible)
+      ExistingDomainController2IP:
+        default: IP the Instance will be used for DNS (Must be accessible)
+      JoinAndPromote:
+        default: Join and Promote to Domain Controllers
+      KeyPairName:
+        default: Key Pair Name
+      LatestAmiId:
+        default: SSM Parameter Value for lastest AMI ID
       QSS3BucketName:
         default: Quick Start S3 Bucket Name
       QSS3BucketRegion:
         default: Quick Start S3 Bucket Region
       QSS3KeyPrefix:
         default: Quick Start S3 Key Prefix
+      RestoreModeSecret:
+        default: Secret ARN Containing Restore Mode Credentials
+      Subnet1ID:
+        default: Subnet 1 ID
+      Subnet2ID:
+        default: Subnet 2 ID
+      VPCCIDR:
+        default: VPC CIDR
+      VPCID:
+        default: VPC ID
 Parameters:
-  VPCCIDR:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
-    Default: 10.0.0.0/16
-    Description: CIDR Block for the VPC
-    Type: String
-  VPCID:
-    Description: ID of the VPC (e.g., vpc-0343606e)
-    Type: AWS::EC2::VPC::Id
-  Subnet1ID:
-    Description: ID of subnet 1 in Availability Zone 1 (e.g., subnet-a0246dcd)
-    Type: AWS::EC2::Subnet::Id
-  Subnet2ID:
-    Description: ID of subnet 2 in Availability Zone 2 (e.g., subnet-a0246dcd)
-    Type: AWS::EC2::Subnet::Id
-  DomainControllersSG:
-    Description: Security Group ID for Domain Controllers
-    Type: AWS::EC2::SecurityGroup::Id
-  ADServerInstanceType:
-    AllowedValues:
-      - t2.medium
-      - t3.medium
-      - t2.large
-      - t3.large
-      - m4.large
-      - m4.xlarge
-      - m4.2xlarge
-      - m4.4xlarge
-      - m5.large
-      - m5.xlarge
-      - m5.2xlarge
-      - m5.4xlarge
-    Default: m5.large
-    Description: Amazon EC2 instance type for Active Directory Controller instances
-    Type: String
   ADServer1NetBIOSName:
     AllowedPattern: '[a-zA-Z0-9\-]+'
     Default: DC3
@@ -154,30 +113,45 @@ Parameters:
     Default: 10.0.32.11
     Description: Fixed private IP for the second additional Active Directory Domain Controller located in subnet 2
     Type: String
+  ADServerInstanceType:
+    AllowedValues:
+      - t2.medium
+      - t3.medium
+      - t2.large
+      - t3.large
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - m5.large
+      - m5.xlarge
+      - m5.2xlarge
+      - m5.4xlarge
+    Default: m5.large
+    Description: Amazon EC2 instance type for Active Directory Controller instances
+    Type: String
+  AdministratorSecret:
+    Default: arn:aws:secretsmanager:us-east-1:############:secret:admin-creds-example
+    Description: ARN for the Administrator credentials Secret used to join and promote domain controllers (Only used if JoinAndPromote is Yes)
+    Type: String
   DataDriveSizeGiB:
     Default: '10'
     Description: Size of SYSVOL and NTDS data drive in GiB
-    Type: 'Number'
-  KeyPairName:
-    Description: Public/private key pairs allow you to securely connect to your instance after it launches
-    Type: AWS::EC2::KeyPair::KeyName
-  LatestAmiId:
-    Default: /aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base
-    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
-  JoinAndPromote:
-    AllowedValues:
-      - 'Yes'
-      - 'No'
-    Default: 'No'
-    Description: Do you want to join and promote these instances to be Active Directory Domain Controllers
+    Type: Number
+  DomainDNSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+\..+'
+    Default: example.com
+    Description: Fully qualified domain name (FQDN) of the domain you would like to join and promote to e.g. example.com
+    MaxLength: '255'
+    MinLength: '2'
     Type: String
-  AdministratorSecret:
-    Default: 'arn:aws:secretsmanager:us-east-1:############:secret:admin-creds-example'
-    Description: ARN for the Administrator credentials Secret used to join and promote domain controllers (Only used if JoinAndPromote is Yes)
-    Type: String
-  RestoreModeSecret:
-    Default: 'arn:aws:secretsmanager:us-east-1:############:secret:restore-creds-example'
-    Description: ARN for the Restore Mode credentials Secret used to join and promote domain controllers (Only used if JoinAndPromote is Yes)
+  DomainNetBIOSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+'
+    Default: example
+    Description:
+      NetBIOS name of the domain (up to 15 characters) you would like to join and promote to for users of earlier versions of Windows e.g. EXAMPLE
+    MaxLength: '15'
+    MinLength: '1'
     Type: String
   ExistingDomainController1IP:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
@@ -189,26 +163,27 @@ Parameters:
     Default: 10.0.32.10
     Description: IP of DNS server that can resolve domain (Must be accessible)
     Type: String
-  DomainDNSName:
-    AllowedPattern: '[a-zA-Z0-9\-]+\..+'
-    Default: example.com
-    Description: Fully qualified domain name (FQDN) of the domain you would like to join and promote to e.g. example.com
-    MaxLength: '255'
-    MinLength: '2'
+  JoinAndPromote:
+    AllowedValues:
+      - 'Yes'
+      - 'No'
+    Default: 'No'
+    Description: Do you want to join and promote these instances to be Active Directory Domain Controllers
     Type: String
-  DomainNetBIOSName:
-    AllowedPattern: '[a-zA-Z0-9\-]+'
-    Default: example
-    Description: NetBIOS name of the domain (up to 15 characters) you would like to join and promote to for users of earlier versions of Windows e.g. EXAMPLE
-    MaxLength: '15'
-    MinLength: '1'
-    Type: String
+  KeyPairName:
+    Description: Public/private key pairs allow you to securely connect to your instance after it launches
+    Type: AWS::EC2::KeyPair::KeyName
+  LatestAmiId:
+    Default: /aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
   QSS3BucketName:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
-    ConstraintDescription: Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen
-      (-).
+    ConstraintDescription:
+      Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
     Default: aws-quickstart
-    Description: S3 bucket name for CA CRL storage. Bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)
+    Description:
+      S3 bucket name for CA CRL storage. Bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or
+      end with a hyphen (-)
     Type: String
   QSS3BucketRegion:
     Default: us-east-1
@@ -218,8 +193,29 @@ Parameters:
     AllowedPattern: ^[0-9a-zA-Z-/]*$
     ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)
     Default: quickstart-microsoft-activedirectory/
-    Description: S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)
+    Description:
+      S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and
+      forward slash (/)
     Type: String
+  RestoreModeSecret:
+    Default: arn:aws:secretsmanager:us-east-1:############:secret:restore-creds-example
+    Description: ARN for the Restore Mode credentials Secret used to join and promote domain controllers (Only used if JoinAndPromote is Yes)
+    Type: String
+  Subnet1ID:
+    Description: ID of subnet 1 in Availability Zone 1 (e.g., subnet-a0246dcd)
+    Type: AWS::EC2::Subnet::Id
+  Subnet2ID:
+    Description: ID of subnet 2 in Availability Zone 2 (e.g., subnet-a0246dcd)
+    Type: AWS::EC2::Subnet::Id
+  VPCCIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.0.0/16
+    Description: CIDR Block for the VPC
+    Type: String
+  VPCID:
+    Description: ID of the VPC (e.g., vpc-0343606e)
+    Type: AWS::EC2::VPC::Id
 Rules:
   SubnetsInVPC:
     Assertions:
@@ -230,732 +226,688 @@ Rules:
           - !RefAll 'AWS::EC2::VPC::Id'
         AssertDescription: All subnets must in the VPC
   SecretValidation:
-    RuleCondition: !Equals
-      - !Ref JoinAndPromote
-      - 'Yes'
+    RuleCondition: !Equals [!Ref JoinAndPromote, 'Yes']
     Assertions:
       - AssertDescription: The Administrator Secret must be valid
         Assert: !Not [!Equals [!Ref AdministratorSecret, 'arn:aws:secretsmanager:us-east-1:############:secret:admin-creds-example']]
       - AssertDescription: The Restore Mode Secret must be valid
         Assert: !Not [!Equals [!Ref RestoreModeSecret, 'arn:aws:secretsmanager:us-east-1:############:secret:restore-creds-example']]
 Conditions:
-  UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
   DoJoinAndPromote: !Equals [!Ref JoinAndPromote, 'Yes']
   DoNOTJoinAndPromote: !Equals [!Ref JoinAndPromote, 'No']
+  UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
 Resources:
   AWSQuickstartActiveDirectoryDS:
-    Type: AWS::SSM::Document
     Condition: DoNOTJoinAndPromote
-    Properties:
-      DocumentType: Automation
-      Content:
-        schemaVersion: "0.3"
-        description: "Deploy non-promoted domain contollers with SSM Automation"
-        # Gathering parameters needed to configure DCs in the Quick Start
-        parameters:
-          VPCCIDR:
-            default: '10.0.0.0/16'
-            description: "CIDR Block for the VPC"
-            type: "String"
-          ADServer1NetBIOSName:
-            default: "DC1"
-            description: "NetBIOS name of the first Active Directory Domain Controller (up to 15 characters)"
-            type: "String"
-          ADServer2NetBIOSName:
-            default: "DC2"
-            description: "NetBIOS name of the first Active Directory Domain Controller (up to 15 characters)"
-            type: "String"
-          ExistingDomainController1IP:
-            description: "IP of DNS server that can resolve domain (Must be accessible)"
-            type: "String"
-          ExistingDomainController2IP:
-            description: "IP of DNS server that can resolve domain (Must be accessible)"
-            type: "String"
-          DomainDNSName: 
-            default: "example.com"
-            description: "Fully qualified domain name (FQDN) of the domain you would like to join and promote to e.g. example.com"
-            type: "String"
-          DomainNetBIOSName: 
-            default: "example"
-            description: "NetBIOS name of the domain (up to 15 characters) you would like to join and promote to for users of earlier versions of Windows e.g. EXAMPLE"
-            type: "String"
-          QSS3BucketName:
-            default: "aws-quickstart"
-            description: "S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)"
-            type: "String"
-          QSS3BucketRegion:
-            default: "us-east-1"
-            description: "The AWS Region where the Quick Start S3 bucket (QSS3BucketName) is hosted. When using your own bucket, you must specify this value"
-            type: "String"
-          QSS3KeyPrefix:
-            default: "quickstart-microsoft-activedirectory/"
-            description: "S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)"
-            type: "String"
-          StackName:
-            default: ""
-            description: "Stack Name Input for cfn resource signal"
-            type: "String"
-          URLSuffix:
-            default: "amazonaws.com"
-            description: "AWS URL suffix"
-            type: "String"
-        mainSteps:
-        # This step grabs the Instance IDs for both nodes that will be configured as DCs in the Quick Start and Instance IDs for the for next steps.
-        - name: "dcsInstanceIds"
-          action: aws:executeAwsApi
-          onFailure: "step:signalfailure"
-          nextStep: "dc1InstanceId"
-          inputs:
-            Service: ec2
-            Api: DescribeInstances
-            Filters:  
-            - Name: "tag:Name"
-              Values: [ "{{ADServer1NetBIOSName}}","{{ADServer2NetBIOSName}}" ]
-            - Name: "tag:aws:cloudformation:stack-name"
-              Values: ["{{StackName}}"]
-            - Name: "instance-state-name"
-              Values: [ "running" ]
-          outputs:
-          - Name: InstanceIds
-            Selector: "$.Reservations..Instances..InstanceId"
-            Type: "StringList"
-        # This step grabs the Instance ID for the node that will be configured as the first DC in the new domain.
-        - name: "dc1InstanceId"
-          action: aws:executeAwsApi
-          onFailure: "step:signalfailure"
-          nextStep: "dc2InstanceId"
-          inputs:
-            Service: ec2
-            Api: DescribeInstances
-            Filters:  
-            - Name: "tag:Name"
-              Values: [ "{{ADServer1NetBIOSName}}" ]
-            - Name: "tag:aws:cloudformation:stack-name"
-              Values: ["{{StackName}}"]
-            - Name: "instance-state-name"
-              Values: [ "running" ]
-          outputs:
-          - Name: InstanceId
-            Selector: "$.Reservations[0].Instances[0].InstanceId"
-            Type: "String"
-        # This step grabs the Instance ID for the node that will be configured as the second DC in the new domain.
-        - name: "dc2InstanceId"
-          action: aws:executeAwsApi
-          onFailure: "step:signalfailure"
-          nextStep: "dcsInstallDscModules"
-          inputs:
-            Service: ec2
-            Api: DescribeInstances
-            Filters:  
-            - Name: "tag:Name"
-              Values: [ "{{ADServer2NetBIOSName}}" ]
-            - Name: "tag:aws:cloudformation:stack-name"
-              Values: ["{{StackName}}"]
-            - Name: "instance-state-name"
-              Values: [ "running" ]
-          outputs:
-          - Name: InstanceId
-            Selector: "$.Reservations[0].Instances[0].InstanceId"
-            Type: "String"
-        # Installs needed Powershell DSC Modules and components on both nodes.
-        - name: "dcsInstallDscModules"
-          action: "aws:runCommand"
-          onFailure: "step:signalfailure"
-          nextStep: "dcsLCMConfig"
-          inputs:
-            DocumentName: "AWS-RunRemoteScript"
-            InstanceIds:
-            - "{{dcsInstanceIds.InstanceIds}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              sourceType: "S3"
-              sourceInfo: 
-                !Sub 
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/install-ad-modules.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If 
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: "./install-ad-modules.ps1"
-        # Configures Local Configuration Manager on each of the nodes.
-        - name: "dcsLCMConfig"
-          action: "aws:runCommand"
-          onFailure: "step:signalfailure"
-          nextStep: "dc1createDCMof"
-          inputs:
-            DocumentName: "AWS-RunRemoteScript"
-            InstanceIds:
-            - "{{dcsInstanceIds.InstanceIds}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              sourceType: "S3"
-              sourceInfo: 
-                !Sub 
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/LCM-Config.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If 
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: "./LCM-Config.ps1"
-        # Generates MOF file on second DC Node to be processed by LCM.
-        - name: "dc1createDCMof"
-          action: "aws:runCommand"
-          onFailure: "step:signalfailure"
-          nextStep: "dc1configDC"
-          inputs:
-            DocumentName: "AWS-RunRemoteScript"
-            InstanceIds:
-            - "{{dc1InstanceId.InstanceId}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              sourceType: "S3"
-              sourceInfo: 
-                !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AD2-NonPromoConfig.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If 
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: "./AD2-NonPromoConfig.ps1 -ADServerNetBIOSName {{ADServer1NetBIOSName}} -DomainNetBIOSName {{DomainNetBIOSName}} -DomainDNSName {{DomainDNSName}} -ADServer1PrivateIP {{ExistingDomainController1IP}} -ADServer2PrivateIP {{ExistingDomainController2IP}}"
-        # Kicks off DSC Configuration and loops\reboots until Node matches Configuration defined in MOF file.
-        - name: "dc1configDC"
-          action: aws:runCommand
-          onFailure: "step:signalfailure"
-          nextStep: "dc2createDCMof"
-          inputs:
-            DocumentName: AWS-RunPowerShellScript
-            InstanceIds: 
-            - "{{dc1InstanceId.InstanceId}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              commands: 
-                - |     
-                   function DscStatusCheck () {
-                       $LCMState = (Get-DscLocalConfigurationManager).LCMState
-                       if ($LCMState -eq 'PendingConfiguration' -Or $LCMState -eq 'PendingReboot') {
-                           'returning 3010, should continue after reboot'
-                           exit 3010
-                       } else {
-                           'Completed'
-                       }
-                   }
-                   
-                   Start-DscConfiguration 'C:\AWSQuickstart\NonPromoConfig' -Wait -Verbose -Force
-                   
-                   DscStatusCheck
-        # Generates MOF file on second DC Node to be processed by LCM.
-        - name: "dc2createDCMof"
-          action: "aws:runCommand"
-          onFailure: "step:signalfailure"
-          nextStep: "dc2configDC"
-          inputs:
-            DocumentName: "AWS-RunRemoteScript"
-            InstanceIds:
-            - "{{dc2InstanceId.InstanceId}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              sourceType: "S3"
-              sourceInfo: 
-                !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AD2-NonPromoConfig.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If 
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: "./AD2-NonPromoConfig.ps1 -ADServerNetBIOSName {{ADServer2NetBIOSName}} -DomainNetBIOSName {{DomainNetBIOSName}} -DomainDNSName {{DomainDNSName}} -ADServer1PrivateIP {{ExistingDomainController1IP}} -ADServer2PrivateIP {{ExistingDomainController2IP}}"
-        # Kicks off DSC Configuration and loops\reboots until Node matches Configuration defined in MOF file.
-        - name: "dc2configDC"
-          action: aws:runCommand
-          onFailure: "step:signalfailure"
-          nextStep: "PostConfig"
-          inputs:
-            DocumentName: AWS-RunPowerShellScript
-            InstanceIds: 
-            - "{{dc2InstanceId.InstanceId}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              commands: 
-                - |     
-                   function DscStatusCheck () {
-                       $LCMState = (Get-DscLocalConfigurationManager).LCMState
-                       if ($LCMState -eq 'PendingConfiguration' -Or $LCMState -eq 'PendingReboot') {
-                           'returning 3010, should continue after reboot'
-                           exit 3010
-                       } else {
-                           'Completed'
-                       }
-                   }
-                   
-                   Start-DscConfiguration 'C:\AWSQuickstart\NonPromoConfig' -Wait -Verbose -Force
-                   
-                   DscStatusCheck
-        # Cleanup and finalize setup
-        - name: "PostConfig"
-          action: "aws:runCommand"
-          onFailure: "step:signalfailure"
-          inputs:
-            DocumentName: "AWS-RunRemoteScript"
-            InstanceIds:
-              - "{{dcsInstanceIds.InstanceIds}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              sourceType: S3
-              sourceInfo: 
-                !Sub 
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AD2-Post-Config.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If 
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: "./AD2-Post-Config.ps1 -VPCCIDR {{VPCCIDR}}"
-        # Determines if CFN Needs to be Signaled or if Work flow should just end
-        - name: "CFNSignalEnd"
-          action: aws:branch
-          inputs:
-            Choices:
-            - NextStep: signalsuccess
-              Not: 
-                Variable: "{{StackName}}"
-                StringEquals: ""
-            - NextStep: sleepend
-              Variable: "{{StackName}}"
-              StringEquals: ""
-        # If all steps complete successfully signals CFN of Success
-        - name: "signalsuccess"
-          action: "aws:executeAwsApi"
-          isEnd: True
-          inputs:
-            Service: cloudformation
-            Api: SignalResource
-            LogicalResourceId: "DomainController2"
-            StackName: "{{StackName}}"
-            Status: SUCCESS
-            UniqueId: "{{dc2InstanceId.InstanceId}}"
-        # If CFN Signl Not Needed this sleep ends work flow
-        - name: "sleepend"
-          action: "aws:sleep"
-          isEnd: True
-          inputs:
-            Duration: PT1S
-        # If any steps fails signals CFN of Failure
-        - name: "signalfailure"
-          action: "aws:executeAwsApi"
-          inputs:
-            Service: cloudformation
-            Api: SignalResource
-            LogicalResourceId: "DomainController2"
-            StackName: "{{StackName}}"
-            Status: FAILURE
-            UniqueId: "{{dc2InstanceId.InstanceId}}"
-  AWSQuickstartActiveDirectoryDSPromote:
     Type: AWS::SSM::Document
-    Condition: DoJoinAndPromote
     Properties:
       DocumentType: Automation
+      Tags:
+        - Key: StackName
+          Value: !Ref AWS::StackName
       Content:
-        schemaVersion: "0.3"
-        description: "Deploy promoted domain contollers with SSM Automation"
+        schemaVersion: '0.3'
+        description: 'Deploy non-promoted domain contollers with SSM Automation'
         # Gathering parameters needed to configure DCs in the Quick Start
         parameters:
           VPCCIDR:
             default: '10.0.0.0/16'
-            description: "CIDR block for private subnet 1 located in Availability Zone 1"
-            type: "String"
+            description: 'CIDR Block for the VPC'
+            type: 'String'
           ADServer1NetBIOSName:
-            default: "DC1"
-            description: "NetBIOS name of the first Active Directory Domain Controller (up to 15 characters)"
-            type: "String"
-          ADServer1PrivateIP:
-            default: "10.0.0.11"
-            description: "Fixed private IP for the first additional Active Directory Domain Controller located in subnet 1"
-            type: "String"
+            default: 'DC1'
+            description: 'NetBIOS name of the first Active Directory Domain Controller (up to 15 characters)'
+            type: 'String'
           ADServer2NetBIOSName:
-            default: "DC2"
-            description: "NetBIOS name of the first Active Directory Domain Controller (up to 15 characters)"
-            type: "String"
-          ADServer2PrivateIP:
-            default: "10.0.32.11"
-            description: "Fixed private IP for the second additional Active Directory Domain Controller located in subnet 2"
-            type: "String"
-          ADAdminSecParamName:
-            description: "ARN for the Administrator credentials Secret used to join and promote domain controllers (Only used if JoinAndPromote is Yes)"
-            type: "String"
-          RestoreModeSecParamName:
-            description: "ARN for the Restore Mode credentials Secret used to join and promote domain controllers (Only used if JoinAndPromote is Yes)"
-            type: "String"
+            default: 'DC2'
+            description: 'NetBIOS name of the first Active Directory Domain Controller (up to 15 characters)'
+            type: 'String'
           ExistingDomainController1IP:
-            description: "IP of DNS server that can resolve domain (Must be accessible)"
-            type: "String"
-          DomainDNSName: 
-            default: "example.com"
-            description: "Fully qualified domain name (FQDN) of the domain you would like to join and promote to e.g. example.com"
-            type: "String"
-          DomainNetBIOSName: 
-            default: "example"
-            description: "NetBIOS name of the domain (up to 15 characters) you would like to join and promote to for users of earlier versions of Windows e.g. EXAMPLE"
-            type: "String"
+            description: 'IP of DNS server that can resolve domain (Must be accessible)'
+            type: 'String'
+          ExistingDomainController2IP:
+            description: 'IP of DNS server that can resolve domain (Must be accessible)'
+            type: 'String'
+          DomainDNSName:
+            default: 'example.com'
+            description: 'Fully qualified domain name (FQDN) of the domain you would like to join and promote to e.g. example.com'
+            type: 'String'
+          DomainNetBIOSName:
+            default: 'example'
+            description:
+              'NetBIOS name of the domain (up to 15 characters) you would like to join and promote to for users of earlier versions of Windows e.g.
+              EXAMPLE'
+            type: 'String'
           QSS3BucketName:
-            default: "aws-quickstart"
-            description: "S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)"
-            type: "String"
+            default: 'aws-quickstart'
+            description:
+              'S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and
+              hyphens (-). It cannot start or end with a hyphen (-)'
+            type: 'String'
           QSS3BucketRegion:
-            default: "us-east-1"
-            description: "The AWS Region where the Quick Start S3 bucket (QSS3BucketName) is hosted. When using your own bucket, you must specify this value"
-            type: "String"
+            default: 'us-east-1'
+            description:
+              'The AWS Region where the Quick Start S3 bucket (QSS3BucketName) is hosted. When using your own bucket, you must specify this value'
+            type: 'String'
           QSS3KeyPrefix:
-            default: "quickstart-microsoft-activedirectory/"
-            description: "S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)"
-            type: "String"
+            default: 'quickstart-microsoft-activedirectory/'
+            description:
+              'S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens
+              (-), and forward slash (/)'
+            type: 'String'
           StackName:
-            default: ""
-            description: "Stack Name Input for cfn resource signal"
-            type: "String"
+            default: ''
+            description: 'Stack Name Input for cfn resource signal'
+            type: 'String'
           URLSuffix:
-            default: "amazonaws.com"
-            description: "AWS URL suffix"
-            type: "String"
+            default: 'amazonaws.com'
+            description: 'AWS URL suffix'
+            type: 'String'
         mainSteps:
-        # This step grabs the Instance IDs for both nodes that will be configured as DCs in the Quick Start and Instance IDs for the for next steps.
-        - name: "dcsInstanceIds"
-          action: aws:executeAwsApi
-          onFailure: "step:signalfailure"
-          nextStep: "dc1InstanceId"
-          inputs:
-            Service: ec2
-            Api: DescribeInstances
-            Filters:  
-            - Name: "tag:Name"
-              Values: [ "{{ADServer1NetBIOSName}}","{{ADServer2NetBIOSName}}" ]
-            - Name: "tag:aws:cloudformation:stack-name"
-              Values: ["{{StackName}}"]
-            - Name: "instance-state-name"
-              Values: [ "running" ]
-          outputs:
-          - Name: InstanceIds
-            Selector: "$.Reservations..Instances..InstanceId"
-            Type: "StringList"
-        # This step grabs the Instance ID for the node that will be configured as the first DC in the new domain.
-        - name: "dc1InstanceId"
-          action: aws:executeAwsApi
-          onFailure: "step:signalfailure"
-          nextStep: "dc2InstanceId"
-          inputs:
-            Service: ec2
-            Api: DescribeInstances
-            Filters:  
-            - Name: "tag:Name"
-              Values: [ "{{ADServer1NetBIOSName}}" ]
-            - Name: "tag:aws:cloudformation:stack-name"
-              Values: ["{{StackName}}"]
-            - Name: "instance-state-name"
-              Values: [ "running" ]
-          outputs:
-          - Name: InstanceId
-            Selector: "$.Reservations[0].Instances[0].InstanceId"
-            Type: "String"
-        # This step grabs the Instance ID for the node that will be configured as the second DC in the new domain.
-        - name: "dc2InstanceId"
-          action: aws:executeAwsApi
-          onFailure: "step:signalfailure"
-          nextStep: "dcsInstallDscModules"
-          inputs:
-            Service: ec2
-            Api: DescribeInstances
-            Filters:  
-            - Name: "tag:Name"
-              Values: [ "{{ADServer2NetBIOSName}}" ]
-            - Name: "tag:aws:cloudformation:stack-name"
-              Values: ["{{StackName}}"]
-            - Name: "instance-state-name"
-              Values: [ "running" ]
-          outputs:
-          - Name: InstanceId
-            Selector: "$.Reservations[0].Instances[0].InstanceId"
-            Type: "String"
-        # Installs needed Powershell DSC Modules and components on both nodes.
-        - name: "dcsInstallDscModules"
-          action: "aws:runCommand"
-          onFailure: "step:signalfailure"
-          nextStep: "dcsLCMConfig"
-          inputs:
-            DocumentName: "AWS-RunRemoteScript"
-            InstanceIds:
-            - "{{dcsInstanceIds.InstanceIds}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              sourceType: "S3"
-              sourceInfo: 
-                !Sub 
+          # This step grabs the Instance IDs for both nodes that will be configured as DCs in the Quick Start and Instance IDs for the for next steps.
+          - name: 'dcsInstanceIds'
+            action: aws:executeAwsApi
+            onFailure: 'step:signalfailure'
+            nextStep: 'dc1InstanceId'
+            inputs:
+              Service: ec2
+              Api: DescribeInstances
+              Filters:
+                - Name: 'tag:Name'
+                  Values: ['{{ADServer1NetBIOSName}}', '{{ADServer2NetBIOSName}}']
+                - Name: 'tag:aws:cloudformation:stack-name'
+                  Values: ['{{StackName}}']
+                - Name: 'instance-state-name'
+                  Values: ['running']
+            outputs:
+              - Name: InstanceIds
+                Selector: '$.Reservations..Instances..InstanceId'
+                Type: 'StringList'
+          # This step grabs the Instance ID for the node that will be configured as the first DC in the new domain.
+          - name: 'dc1InstanceId'
+            action: aws:executeAwsApi
+            onFailure: 'step:signalfailure'
+            nextStep: 'dc2InstanceId'
+            inputs:
+              Service: ec2
+              Api: DescribeInstances
+              Filters:
+                - Name: 'tag:Name'
+                  Values: ['{{ADServer1NetBIOSName}}']
+                - Name: 'tag:aws:cloudformation:stack-name'
+                  Values: ['{{StackName}}']
+                - Name: 'instance-state-name'
+                  Values: ['running']
+            outputs:
+              - Name: InstanceId
+                Selector: '$.Reservations[0].Instances[0].InstanceId'
+                Type: 'String'
+          # This step grabs the Instance ID for the node that will be configured as the second DC in the new domain.
+          - name: 'dc2InstanceId'
+            action: aws:executeAwsApi
+            onFailure: 'step:signalfailure'
+            nextStep: 'dcsInstallDscModules'
+            inputs:
+              Service: ec2
+              Api: DescribeInstances
+              Filters:
+                - Name: 'tag:Name'
+                  Values: ['{{ADServer2NetBIOSName}}']
+                - Name: 'tag:aws:cloudformation:stack-name'
+                  Values: ['{{StackName}}']
+                - Name: 'instance-state-name'
+                  Values: ['running']
+            outputs:
+              - Name: InstanceId
+                Selector: '$.Reservations[0].Instances[0].InstanceId'
+                Type: 'String'
+          # Installs needed Powershell DSC Modules and components on both nodes.
+          - name: 'dcsInstallDscModules'
+            action: 'aws:runCommand'
+            onFailure: 'step:signalfailure'
+            nextStep: 'dcsLCMConfig'
+            inputs:
+              DocumentName: 'AWS-RunRemoteScript'
+              InstanceIds:
+                - '{{dcsInstanceIds.InstanceIds}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                sourceType: 'S3'
+                sourceInfo: !Sub
                   - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/install-ad-modules.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If 
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: "./install-ad-modules.ps1"
-        # Configures Local Configuration Manager on each of the nodes.
-        - name: "dcsLCMConfig"
-          action: "aws:runCommand"
-          onFailure: "step:signalfailure"
-          nextStep: "dc1createDCMof"
-          inputs:
-            DocumentName: "AWS-RunRemoteScript"
-            InstanceIds:
-            - "{{dcsInstanceIds.InstanceIds}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              sourceType: "S3"
-              sourceInfo: 
-                !Sub 
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+                    S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+                commandLine: './install-ad-modules.ps1'
+          # Configures Local Configuration Manager on each of the nodes.
+          - name: 'dcsLCMConfig'
+            action: 'aws:runCommand'
+            onFailure: 'step:signalfailure'
+            nextStep: 'dc1createDCMof'
+            inputs:
+              DocumentName: 'AWS-RunRemoteScript'
+              InstanceIds:
+                - '{{dcsInstanceIds.InstanceIds}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                sourceType: 'S3'
+                sourceInfo: !Sub
                   - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/LCM-Config.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If 
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: "./LCM-Config.ps1"
-        # Generates MOF file on second DC Node to be processed by LCM.
-        - name: "dc1createDCMof"
-          action: "aws:runCommand"
-          onFailure: "step:signalfailure"
-          nextStep: "dc1configDC"
-          inputs:
-            DocumentName: "AWS-RunRemoteScript"
-            InstanceIds:
-            - "{{dc1InstanceId.InstanceId}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              sourceType: "S3"
-              sourceInfo: 
-                !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/ConfigDC2.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If 
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: "./ConfigDC2.ps1 -ADServer2NetBIOSName {{ADServer1NetBIOSName}} -DomainNetBIOSName {{DomainNetBIOSName}} -DomainDNSName {{DomainDNSName}} -ADServer1PrivateIP {{ExistingDomainController1IP}} -ADAdminSecParam {{ADAdminSecParamName}} -RestoreModeSecParam {{RestoreModeSecParamName}}"
-        # Kicks off DSC Configuration and loops\reboots until Node matches Configuration defined in MOF file.
-        - name: "dc1configDC"
-          action: aws:runCommand
-          onFailure: "step:signalfailure"
-          nextStep: "dc2createDCMof"
-          inputs:
-            DocumentName: AWS-RunPowerShellScript
-            InstanceIds: 
-            - "{{dc1InstanceId.InstanceId}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              commands: 
-                - |     
-                   function DscStatusCheck () {
-                       $LCMState = (Get-DscLocalConfigurationManager).LCMState
-                       if ($LCMState -eq 'PendingConfiguration' -Or $LCMState -eq 'PendingReboot') {
-                           'returning 3010, should continue after reboot'
-                           exit 3010
-                       } else {
-                           'Completed'
-                       }
-                   }
-                   
-                   Start-DscConfiguration 'C:\AWSQuickstart\ConfigDC2' -Wait -Verbose -Force
-                   
-                   DscStatusCheck
-        # Generates MOF file on second DC Node to be processed by LCM.
-        - name: "dc2createDCMof"
-          action: "aws:runCommand"
-          onFailure: "step:signalfailure"
-          nextStep: "dc2configDC"
-          inputs:
-            DocumentName: "AWS-RunRemoteScript"
-            InstanceIds:
-            - "{{dc2InstanceId.InstanceId}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              sourceType: "S3"
-              sourceInfo: 
-                !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/ConfigDC2.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If 
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: "./ConfigDC2.ps1 -ADServer2NetBIOSName {{ADServer2NetBIOSName}} -DomainNetBIOSName {{DomainNetBIOSName}} -DomainDNSName {{DomainDNSName}} -ADServer1PrivateIP {{ExistingDomainController1IP}} -ADAdminSecParam {{ADAdminSecParamName}} -RestoreModeSecParam {{RestoreModeSecParamName}}"
-        # Kicks off DSC Configuration and loops\reboots until Node matches Configuration defined in MOF file.
-        - name: "dc2configDC"
-          action: aws:runCommand
-          onFailure: "step:signalfailure"
-          nextStep: "DnsConfig"
-          inputs:
-            DocumentName: AWS-RunPowerShellScript
-            InstanceIds: 
-            - "{{dc2InstanceId.InstanceId}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              commands: 
-                - |     
-                   function DscStatusCheck () {
-                       $LCMState = (Get-DscLocalConfigurationManager).LCMState
-                       if ($LCMState -eq 'PendingConfiguration' -Or $LCMState -eq 'PendingReboot') {
-                           'returning 3010, should continue after reboot'
-                           exit 3010
-                       } else {
-                           'Completed'
-                       }
-                   }
-                   
-                   Start-DscConfiguration 'C:\AWSQuickstart\ConfigDC2' -Wait -Verbose -Force
-                   
-                   DscStatusCheck
-        # Ensure that AD servers point to themselves for DNS
-        - name: "DnsConfig"
-          action: "aws:runCommand"
-          onFailure: "step:signalfailure"
-          nextStep: "PostConfig"
-          inputs:
-            DocumentName: "AWS-RunRemoteScript"
-            InstanceIds:
-            - "{{dc2InstanceId.InstanceId}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              sourceType: S3
-              sourceInfo: 
-                !Sub 
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Dns-Config.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If 
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: "./Dns-Config.ps1 -ADServer1NetBIOSName {{ADServer1NetBIOSName}} -ADServer2NetBIOSName {{ADServer2NetBIOSName}} -ADServer1PrivateIP {{ADServer1PrivateIP}} -ADServer2PrivateIP {{ADServer2PrivateIP}} -DomainDNSName {{DomainDNSName}} -ADAdminSecParam {{ADAdminSecParamName}}"
-        # Cleanup and finalize setup
-        - name: "PostConfig"
-          action: "aws:runCommand"
-          onFailure: "step:signalfailure"
-          inputs:
-            DocumentName: "AWS-RunRemoteScript"
-            InstanceIds:
-              - "{{dcsInstanceIds.InstanceIds}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              sourceType: S3
-              sourceInfo: 
-                !Sub 
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+                    S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+                commandLine: './LCM-Config.ps1'
+          # Generates MOF file on second DC Node to be processed by LCM.
+          - name: 'dc1createDCMof'
+            action: 'aws:runCommand'
+            onFailure: 'step:signalfailure'
+            nextStep: 'dc1configDC'
+            inputs:
+              DocumentName: 'AWS-RunRemoteScript'
+              InstanceIds:
+                - '{{dc1InstanceId.InstanceId}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                sourceType: 'S3'
+                sourceInfo: !Sub
+                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AD2-NonPromoConfig.ps1"}'
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+                    S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+                commandLine:
+                  './AD2-NonPromoConfig.ps1 -ADServerNetBIOSName {{ADServer1NetBIOSName}} -DomainNetBIOSName {{DomainNetBIOSName}} -DomainDNSName
+                  {{DomainDNSName}} -ADServer1PrivateIP {{ExistingDomainController1IP}} -ADServer2PrivateIP {{ExistingDomainController2IP}}'
+          # Kicks off DSC Configuration and loops\reboots until Node matches Configuration defined in MOF file.
+          - name: 'dc1configDC'
+            action: aws:runCommand
+            onFailure: 'step:signalfailure'
+            nextStep: 'dc2createDCMof'
+            inputs:
+              DocumentName: AWS-RunPowerShellScript
+              InstanceIds:
+                - '{{dc1InstanceId.InstanceId}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                commands:
+                  - |
+                    function DscStatusCheck () {
+                        $LCMState = (Get-DscLocalConfigurationManager).LCMState
+                        if ($LCMState -eq 'PendingConfiguration' -Or $LCMState -eq 'PendingReboot') {
+                            'returning 3010, should continue after reboot'
+                            exit 3010
+                        } else {
+                            'Completed'
+                        }
+                    }
+
+                    Start-DscConfiguration 'C:\AWSQuickstart\NonPromoConfig' -Wait -Verbose -Force
+
+                    DscStatusCheck
+          # Generates MOF file on second DC Node to be processed by LCM.
+          - name: 'dc2createDCMof'
+            action: 'aws:runCommand'
+            onFailure: 'step:signalfailure'
+            nextStep: 'dc2configDC'
+            inputs:
+              DocumentName: 'AWS-RunRemoteScript'
+              InstanceIds:
+                - '{{dc2InstanceId.InstanceId}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                sourceType: 'S3'
+                sourceInfo: !Sub
+                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AD2-NonPromoConfig.ps1"}'
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+                    S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+                commandLine:
+                  './AD2-NonPromoConfig.ps1 -ADServerNetBIOSName {{ADServer2NetBIOSName}} -DomainNetBIOSName {{DomainNetBIOSName}} -DomainDNSName
+                  {{DomainDNSName}} -ADServer1PrivateIP {{ExistingDomainController1IP}} -ADServer2PrivateIP {{ExistingDomainController2IP}}'
+          # Kicks off DSC Configuration and loops\reboots until Node matches Configuration defined in MOF file.
+          - name: 'dc2configDC'
+            action: aws:runCommand
+            onFailure: 'step:signalfailure'
+            nextStep: 'PostConfig'
+            inputs:
+              DocumentName: AWS-RunPowerShellScript
+              InstanceIds:
+                - '{{dc2InstanceId.InstanceId}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                commands:
+                  - |
+                    function DscStatusCheck () {
+                        $LCMState = (Get-DscLocalConfigurationManager).LCMState
+                        if ($LCMState -eq 'PendingConfiguration' -Or $LCMState -eq 'PendingReboot') {
+                            'returning 3010, should continue after reboot'
+                            exit 3010
+                        } else {
+                            'Completed'
+                        }
+                    }
+
+                    Start-DscConfiguration 'C:\AWSQuickstart\NonPromoConfig' -Wait -Verbose -Force
+
+                    DscStatusCheck
+          # Cleanup and finalize setup
+          - name: 'PostConfig'
+            action: 'aws:runCommand'
+            onFailure: 'step:signalfailure'
+            inputs:
+              DocumentName: 'AWS-RunRemoteScript'
+              InstanceIds:
+                - '{{dcsInstanceIds.InstanceIds}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                sourceType: S3
+                sourceInfo: !Sub
                   - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AD2-Post-Config.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If 
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: "./AD2-Post-Config.ps1 -VPCCIDR {{VPCCIDR}}"
-        # Determines if CFN Needs to be Signaled or if Work flow should just end
-        - name: "CFNSignalEnd"
-          action: aws:branch
-          inputs:
-            Choices:
-            - NextStep: signalsuccess
-              Not: 
-                Variable: "{{StackName}}"
-                StringEquals: ""
-            - NextStep: sleepend
-              Variable: "{{StackName}}"
-              StringEquals: ""
-        # If all steps complete successfully signals CFN of Success
-        - name: "signalsuccess"
-          action: "aws:executeAwsApi"
-          isEnd: True
-          inputs:
-            Service: cloudformation
-            Api: SignalResource
-            LogicalResourceId: "DomainController2Promote"
-            StackName: "{{StackName}}"
-            Status: SUCCESS
-            UniqueId: "{{dc2InstanceId.InstanceId}}"
-        # If CFN Signl Not Needed this sleep ends work flow
-        - name: "sleepend"
-          action: "aws:sleep"
-          isEnd: True
-          inputs:
-            Duration: PT1S
-        # If any steps fails signals CFN of Failure
-        - name: "signalfailure"
-          action: "aws:executeAwsApi"
-          inputs:
-            Service: cloudformation
-            Api: SignalResource
-            LogicalResourceId: "DomainController2Promote"
-            StackName: "{{StackName}}"
-            Status: FAILURE
-            UniqueId: "{{dc2InstanceId.InstanceId}}"
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+                    S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+                commandLine: './AD2-Post-Config.ps1 -VPCCIDR {{VPCCIDR}}'
+          # Determines if CFN Needs to be Signaled or if Work flow should just end
+          - name: 'CFNSignalEnd'
+            action: aws:branch
+            inputs:
+              Choices:
+                - NextStep: signalsuccess
+                  Not:
+                    Variable: '{{StackName}}'
+                    StringEquals: ''
+                - NextStep: sleepend
+                  Variable: '{{StackName}}'
+                  StringEquals: ''
+          # If all steps complete successfully signals CFN of Success
+          - name: 'signalsuccess'
+            action: 'aws:executeAwsApi'
+            isEnd: True
+            inputs:
+              Service: cloudformation
+              Api: SignalResource
+              LogicalResourceId: 'DomainController2'
+              StackName: '{{StackName}}'
+              Status: SUCCESS
+              UniqueId: '{{dc2InstanceId.InstanceId}}'
+          # If CFN Signl Not Needed this sleep ends work flow
+          - name: 'sleepend'
+            action: 'aws:sleep'
+            isEnd: True
+            inputs:
+              Duration: PT1S
+          # If any steps fails signals CFN of Failure
+          - name: 'signalfailure'
+            action: 'aws:executeAwsApi'
+            inputs:
+              Service: cloudformation
+              Api: SignalResource
+              LogicalResourceId: 'DomainController2'
+              StackName: '{{StackName}}'
+              Status: FAILURE
+              UniqueId: '{{dc2InstanceId.InstanceId}}'
+  AWSQuickstartActiveDirectoryDSPromote:
+    Condition: DoJoinAndPromote
+    Type: AWS::SSM::Document
+    Properties:
+      DocumentType: Automation
+      Tags:
+        - Key: StackName
+          Value: !Ref AWS::StackName
+      Content:
+        schemaVersion: '0.3'
+        description: 'Deploy promoted domain contollers with SSM Automation'
+        # Gathering parameters needed to configure DCs in the Quick Start
+        parameters:
+          VPCCIDR:
+            default: '10.0.0.0/16'
+            description: 'CIDR block for private subnet 1 located in Availability Zone 1'
+            type: 'String'
+          ADServer1NetBIOSName:
+            default: 'DC1'
+            description: 'NetBIOS name of the first Active Directory Domain Controller (up to 15 characters)'
+            type: 'String'
+          ADServer1PrivateIP:
+            default: '10.0.0.11'
+            description: 'Fixed private IP for the first additional Active Directory Domain Controller located in subnet 1'
+            type: 'String'
+          ADServer2NetBIOSName:
+            default: 'DC2'
+            description: 'NetBIOS name of the first Active Directory Domain Controller (up to 15 characters)'
+            type: 'String'
+          ADServer2PrivateIP:
+            default: '10.0.32.11'
+            description: 'Fixed private IP for the second additional Active Directory Domain Controller located in subnet 2'
+            type: 'String'
+          ADAdminSecParamName:
+            description:
+              'ARN for the Administrator credentials Secret used to join and promote domain controllers (Only used if JoinAndPromote is Yes)'
+            type: 'String'
+          RestoreModeSecParamName:
+            description:
+              'ARN for the Restore Mode credentials Secret used to join and promote domain controllers (Only used if JoinAndPromote is Yes)'
+            type: 'String'
+          ExistingDomainController1IP:
+            description: 'IP of DNS server that can resolve domain (Must be accessible)'
+            type: 'String'
+          DomainDNSName:
+            default: 'example.com'
+            description: 'Fully qualified domain name (FQDN) of the domain you would like to join and promote to e.g. example.com'
+            type: 'String'
+          DomainNetBIOSName:
+            default: 'example'
+            description:
+              'NetBIOS name of the domain (up to 15 characters) you would like to join and promote to for users of earlier versions of Windows e.g.
+              EXAMPLE'
+            type: 'String'
+          QSS3BucketName:
+            default: 'aws-quickstart'
+            description:
+              'S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and
+              hyphens (-). It cannot start or end with a hyphen (-)'
+            type: 'String'
+          QSS3BucketRegion:
+            default: 'us-east-1'
+            description:
+              'The AWS Region where the Quick Start S3 bucket (QSS3BucketName) is hosted. When using your own bucket, you must specify this value'
+            type: 'String'
+          QSS3KeyPrefix:
+            default: 'quickstart-microsoft-activedirectory/'
+            description:
+              'S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens
+              (-), and forward slash (/)'
+            type: 'String'
+          StackName:
+            default: ''
+            description: 'Stack Name Input for cfn resource signal'
+            type: 'String'
+          URLSuffix:
+            default: 'amazonaws.com'
+            description: 'AWS URL suffix'
+            type: 'String'
+        mainSteps:
+          # This step grabs the Instance IDs for both nodes that will be configured as DCs in the Quick Start and Instance IDs for the for next steps.
+          - name: 'dcsInstanceIds'
+            action: aws:executeAwsApi
+            onFailure: 'step:signalfailure'
+            nextStep: 'dc1InstanceId'
+            inputs:
+              Service: ec2
+              Api: DescribeInstances
+              Filters:
+                - Name: 'tag:Name'
+                  Values: ['{{ADServer1NetBIOSName}}', '{{ADServer2NetBIOSName}}']
+                - Name: 'tag:aws:cloudformation:stack-name'
+                  Values: ['{{StackName}}']
+                - Name: 'instance-state-name'
+                  Values: ['running']
+            outputs:
+              - Name: InstanceIds
+                Selector: '$.Reservations..Instances..InstanceId'
+                Type: 'StringList'
+          # This step grabs the Instance ID for the node that will be configured as the first DC in the new domain.
+          - name: 'dc1InstanceId'
+            action: aws:executeAwsApi
+            onFailure: 'step:signalfailure'
+            nextStep: 'dc2InstanceId'
+            inputs:
+              Service: ec2
+              Api: DescribeInstances
+              Filters:
+                - Name: 'tag:Name'
+                  Values: ['{{ADServer1NetBIOSName}}']
+                - Name: 'tag:aws:cloudformation:stack-name'
+                  Values: ['{{StackName}}']
+                - Name: 'instance-state-name'
+                  Values: ['running']
+            outputs:
+              - Name: InstanceId
+                Selector: '$.Reservations[0].Instances[0].InstanceId'
+                Type: 'String'
+          # This step grabs the Instance ID for the node that will be configured as the second DC in the new domain.
+          - name: 'dc2InstanceId'
+            action: aws:executeAwsApi
+            onFailure: 'step:signalfailure'
+            nextStep: 'dcsInstallDscModules'
+            inputs:
+              Service: ec2
+              Api: DescribeInstances
+              Filters:
+                - Name: 'tag:Name'
+                  Values: ['{{ADServer2NetBIOSName}}']
+                - Name: 'tag:aws:cloudformation:stack-name'
+                  Values: ['{{StackName}}']
+                - Name: 'instance-state-name'
+                  Values: ['running']
+            outputs:
+              - Name: InstanceId
+                Selector: '$.Reservations[0].Instances[0].InstanceId'
+                Type: 'String'
+          # Installs needed Powershell DSC Modules and components on both nodes.
+          - name: 'dcsInstallDscModules'
+            action: 'aws:runCommand'
+            onFailure: 'step:signalfailure'
+            nextStep: 'dcsLCMConfig'
+            inputs:
+              DocumentName: 'AWS-RunRemoteScript'
+              InstanceIds:
+                - '{{dcsInstanceIds.InstanceIds}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                sourceType: 'S3'
+                sourceInfo: !Sub
+                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/install-ad-modules.ps1"}'
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+                    S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+                commandLine: './install-ad-modules.ps1'
+          # Configures Local Configuration Manager on each of the nodes.
+          - name: 'dcsLCMConfig'
+            action: 'aws:runCommand'
+            onFailure: 'step:signalfailure'
+            nextStep: 'dc1createDCMof'
+            inputs:
+              DocumentName: 'AWS-RunRemoteScript'
+              InstanceIds:
+                - '{{dcsInstanceIds.InstanceIds}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                sourceType: 'S3'
+                sourceInfo: !Sub
+                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/LCM-Config.ps1"}'
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+                    S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+                commandLine: './LCM-Config.ps1'
+          # Generates MOF file on second DC Node to be processed by LCM.
+          - name: 'dc1createDCMof'
+            action: 'aws:runCommand'
+            onFailure: 'step:signalfailure'
+            nextStep: 'dc1configDC'
+            inputs:
+              DocumentName: 'AWS-RunRemoteScript'
+              InstanceIds:
+                - '{{dc1InstanceId.InstanceId}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                sourceType: 'S3'
+                sourceInfo: !Sub
+                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/ConfigDC2.ps1"}'
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+                    S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+                commandLine:
+                  './ConfigDC2.ps1 -ADServer2NetBIOSName {{ADServer1NetBIOSName}} -DomainNetBIOSName {{DomainNetBIOSName}} -DomainDNSName
+                  {{DomainDNSName}} -ADServer1PrivateIP {{ExistingDomainController1IP}} -ADAdminSecParam {{ADAdminSecParamName}} -RestoreModeSecParam
+                  {{RestoreModeSecParamName}}'
+          # Kicks off DSC Configuration and loops\reboots until Node matches Configuration defined in MOF file.
+          - name: 'dc1configDC'
+            action: aws:runCommand
+            onFailure: 'step:signalfailure'
+            nextStep: 'dc2createDCMof'
+            inputs:
+              DocumentName: AWS-RunPowerShellScript
+              InstanceIds:
+                - '{{dc1InstanceId.InstanceId}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                commands:
+                  - |
+                    function DscStatusCheck () {
+                        $LCMState = (Get-DscLocalConfigurationManager).LCMState
+                        if ($LCMState -eq 'PendingConfiguration' -Or $LCMState -eq 'PendingReboot') {
+                            'returning 3010, should continue after reboot'
+                            exit 3010
+                        } else {
+                            'Completed'
+                        }
+                    }
+
+                    Start-DscConfiguration 'C:\AWSQuickstart\ConfigDC2' -Wait -Verbose -Force
+
+                    DscStatusCheck
+          # Generates MOF file on second DC Node to be processed by LCM.
+          - name: 'dc2createDCMof'
+            action: 'aws:runCommand'
+            onFailure: 'step:signalfailure'
+            nextStep: 'dc2configDC'
+            inputs:
+              DocumentName: 'AWS-RunRemoteScript'
+              InstanceIds:
+                - '{{dc2InstanceId.InstanceId}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                sourceType: 'S3'
+                sourceInfo: !Sub
+                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/ConfigDC2.ps1"}'
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+                    S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+                commandLine:
+                  './ConfigDC2.ps1 -ADServer2NetBIOSName {{ADServer2NetBIOSName}} -DomainNetBIOSName {{DomainNetBIOSName}} -DomainDNSName
+                  {{DomainDNSName}} -ADServer1PrivateIP {{ExistingDomainController1IP}} -ADAdminSecParam {{ADAdminSecParamName}} -RestoreModeSecParam
+                  {{RestoreModeSecParamName}}'
+          # Kicks off DSC Configuration and loops\reboots until Node matches Configuration defined in MOF file.
+          - name: 'dc2configDC'
+            action: aws:runCommand
+            onFailure: 'step:signalfailure'
+            nextStep: 'DnsConfig'
+            inputs:
+              DocumentName: AWS-RunPowerShellScript
+              InstanceIds:
+                - '{{dc2InstanceId.InstanceId}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                commands:
+                  - |
+                    function DscStatusCheck () {
+                        $LCMState = (Get-DscLocalConfigurationManager).LCMState
+                        if ($LCMState -eq 'PendingConfiguration' -Or $LCMState -eq 'PendingReboot') {
+                            'returning 3010, should continue after reboot'
+                            exit 3010
+                        } else {
+                            'Completed'
+                        }
+                    }
+
+                    Start-DscConfiguration 'C:\AWSQuickstart\ConfigDC2' -Wait -Verbose -Force
+
+                    DscStatusCheck
+          # Ensure that AD servers point to themselves for DNS
+          - name: 'DnsConfig'
+            action: 'aws:runCommand'
+            onFailure: 'step:signalfailure'
+            nextStep: 'PostConfig'
+            inputs:
+              DocumentName: 'AWS-RunRemoteScript'
+              InstanceIds:
+                - '{{dc2InstanceId.InstanceId}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                sourceType: S3
+                sourceInfo: !Sub
+                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Dns-Config.ps1"}'
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+                    S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+                commandLine:
+                  './Dns-Config.ps1 -ADServer1NetBIOSName {{ADServer1NetBIOSName}} -ADServer2NetBIOSName {{ADServer2NetBIOSName}} -ADServer1PrivateIP
+                  {{ADServer1PrivateIP}} -ADServer2PrivateIP {{ADServer2PrivateIP}} -DomainDNSName {{DomainDNSName}} -ADAdminSecParam
+                  {{ADAdminSecParamName}}'
+          # Cleanup and finalize setup
+          - name: 'PostConfig'
+            action: 'aws:runCommand'
+            onFailure: 'step:signalfailure'
+            inputs:
+              DocumentName: 'AWS-RunRemoteScript'
+              InstanceIds:
+                - '{{dcsInstanceIds.InstanceIds}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                sourceType: S3
+                sourceInfo: !Sub
+                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AD2-Post-Config.ps1"}'
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+                    S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+                commandLine: './AD2-Post-Config.ps1 -VPCCIDR {{VPCCIDR}}'
+          # Determines if CFN Needs to be Signaled or if Work flow should just end
+          - name: 'CFNSignalEnd'
+            action: aws:branch
+            inputs:
+              Choices:
+                - NextStep: signalsuccess
+                  Not:
+                    Variable: '{{StackName}}'
+                    StringEquals: ''
+                - NextStep: sleepend
+                  Variable: '{{StackName}}'
+                  StringEquals: ''
+          # If all steps complete successfully signals CFN of Success
+          - name: 'signalsuccess'
+            action: 'aws:executeAwsApi'
+            isEnd: True
+            inputs:
+              Service: cloudformation
+              Api: SignalResource
+              LogicalResourceId: 'DomainController2Promote'
+              StackName: '{{StackName}}'
+              Status: SUCCESS
+              UniqueId: '{{dc2InstanceId.InstanceId}}'
+          # If CFN Signl Not Needed this sleep ends work flow
+          - name: 'sleepend'
+            action: 'aws:sleep'
+            isEnd: True
+            inputs:
+              Duration: PT1S
+          # If any steps fails signals CFN of Failure
+          - name: 'signalfailure'
+            action: 'aws:executeAwsApi'
+            inputs:
+              Service: cloudformation
+              Api: SignalResource
+              LogicalResourceId: 'DomainController2Promote'
+              StackName: '{{StackName}}'
+              Status: FAILURE
+              UniqueId: '{{dc2InstanceId.InstanceId}}'
   ADServerRole:
     Type: AWS::IAM::Role
     Properties:
@@ -963,17 +915,33 @@ Resources:
         - PolicyDocument:
             Version: '2012-10-17'
             Statement:
-              - Action:
-                  - s3:ListBucket
-                Resource: 
-                  - !Sub ['arn:${AWS::Partition}:s3:::${S3Bucket}', S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]]
-                Effect: Allow
-              - Action:
-                  - s3:GetObject
-                Resource: 
-                  - !Sub ['arn:${AWS::Partition}:s3:::${S3Bucket}/${QSS3KeyPrefix}*', S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]]
-                Effect: Allow
-              - Action:
+              - Effect: Allow
+                Action: s3:GetObject
+                Resource:
+                  - !Sub arn:aws:s3:::aws-ssm-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::aws-windows-downloads-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::amazon-ssm-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::amazon-ssm-packages-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::${AWS::Region}-birdwatcher-prod/*
+                  - !Sub arn:aws:s3:::patch-baseline-snapshot-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::aws-ssm-distributor-file-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::aws-ssm-document-attachments-${AWS::Region}/*
+          PolicyName: SSMAgent
+        - PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: s3:ListBucket
+                Resource: !Sub
+                  - 'arn:${AWS::Partition}:s3:::${S3Bucket}'
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+              - Effect: Allow
+                Action: s3:GetObject
+                Resource: !Sub
+                  - 'arn:${AWS::Partition}:s3:::${S3Bucket}/${QSS3KeyPrefix}*'
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+              - Effect: Allow
+                Action:
                   - ec2:DescribeInstances
                   - ssm:DescribeInstanceInformation
                   - ssm:ListCommands
@@ -981,24 +949,24 @@ Resources:
                   - ssm:SendCommand
                   - ssm:StartAutomationExecution
                 Resource: '*'
-                Effect: Allow
-              - Action:
-                  - cloudformation:SignalResource
+              - Effect: Allow
+                Action: cloudformation:SignalResource
                 Resource: !Sub 'arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*'
-                Effect: Allow
           PolicyName: AWS-Mgmt-Quick-Start-Policy
       Path: /
       ManagedPolicyArns:
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy'
+      Tags:
+        - Key: StackName
+          Value: !Ref AWS::StackName
       AssumeRolePolicyDocument:
         Statement:
-          - Action:
-              - sts:AssumeRole
+          - Effect: Allow
+            Action: sts:AssumeRole
             Principal:
               Service:
                 - ec2.amazonaws.com
-            Effect: Allow
         Version: '2012-10-17'
   ADServerProfile:
     Type: AWS::IAM::InstanceProfile
@@ -1007,8 +975,8 @@ Resources:
         - !Ref 'ADServerRole'
       Path: /
   SecretRolePolicy:
-    Type: AWS::IAM::Policy
     Condition: DoJoinAndPromote
+    Type: AWS::IAM::Policy
     Properties:
       PolicyName: AWS-Mgd-AD-Secret-Role
       PolicyDocument:
@@ -1018,11 +986,19 @@ Resources:
             Action:
               - secretsmanager:GetSecretValue
               - secretsmanager:DescribeSecret
-            Resource: 
+            Resource:
               - !Ref 'AdministratorSecret'
               - !Ref 'RestoreModeSecret'
       Roles:
         - !Ref 'ADServerRole'
+  DomainControllersSG:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Domain Controllers Security Group
+      VpcId: !Ref 'VPCID'
+      Tags:
+        - Key: Name
+          Value: DomainControllersSG
   DomainController1:
     Type: AWS::EC2::Instance
     Properties:
@@ -1033,27 +1009,33 @@ Resources:
       Tags:
         - Key: Name
           Value: !Ref 'ADServer1NetBIOSName'
+        - Key: Domain
+          Value: !Ref 'DomainDNSName'
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeSize: 60
             VolumeType: gp3
+            Encrypted: true
+            DeleteOnTermination: true
         - DeviceName: /dev/xvdf
           Ebs:
             VolumeSize: !Ref 'DataDriveSizeGiB'
             VolumeType: gp3
+            Encrypted: true
+            DeleteOnTermination: true
       SecurityGroupIds:
         - !Ref 'DomainControllersSG'
       PrivateIpAddress: !Ref 'ADServer1PrivateIP'
       KeyName: !Ref 'KeyPairName'
   DomainController2:
-    Type: AWS::EC2::Instance
     Condition: DoNOTJoinAndPromote
-    DependsOn: DomainController1
     CreationPolicy:
       ResourceSignal:
         Timeout: PT60M
         Count: 1
+    DependsOn: DomainController1
+    Type: AWS::EC2::Instance
     Properties:
       ImageId: !Ref 'LatestAmiId'
       IamInstanceProfile: !Ref 'ADServerProfile'
@@ -1062,15 +1044,21 @@ Resources:
       Tags:
         - Key: Name
           Value: !Ref 'ADServer2NetBIOSName'
+        - Key: Domain
+          Value: !Ref 'DomainDNSName'
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeSize: 60
             VolumeType: gp3
+            Encrypted: true
+            DeleteOnTermination: true
         - DeviceName: /dev/xvdf
           Ebs:
             VolumeSize: !Ref 'DataDriveSizeGiB'
             VolumeType: gp3
+            Encrypted: true
+            DeleteOnTermination: true
       SecurityGroupIds:
         - !Ref 'DomainControllersSG'
       PrivateIpAddress: !Ref 'ADServer2PrivateIP'
@@ -1091,7 +1079,7 @@ Resources:
             - ';"ExistingDomainController1IP"='
             - !Sub '"${ExistingDomainController1IP}"'
             - ';"ExistingDomainController2IP"='
-            - !Sub '"${ExistingDomainController2IP}"'           
+            - !Sub '"${ExistingDomainController2IP}"'
             - ';"DomainDNSName"='
             - !Sub '"${DomainDNSName}"'
             - ';"DomainNetBIOSName"='
@@ -1110,13 +1098,13 @@ Resources:
             - "\n"
             - "</powershell>\n"
   DomainController2Promote:
-    Type: AWS::EC2::Instance
     Condition: DoJoinAndPromote
-    DependsOn: DomainController1
     CreationPolicy:
       ResourceSignal:
         Timeout: PT60M
         Count: 1
+    DependsOn: DomainController1
+    Type: AWS::EC2::Instance
     Properties:
       ImageId: !Ref 'LatestAmiId'
       IamInstanceProfile: !Ref 'ADServerProfile'
@@ -1125,15 +1113,21 @@ Resources:
       Tags:
         - Key: Name
           Value: !Ref 'ADServer2NetBIOSName'
+        - Key: Domain
+          Value: !Ref 'DomainDNSName'
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeSize: 60
             VolumeType: gp3
+            Encrypted: true
+            DeleteOnTermination: true
         - DeviceName: /dev/xvdf
           Ebs:
             VolumeSize: !Ref 'DataDriveSizeGiB'
             VolumeType: gp3
+            Encrypted: true
+            DeleteOnTermination: true
       SecurityGroupIds:
         - !Ref 'DomainControllersSG'
       PrivateIpAddress: !Ref 'ADServer2PrivateIP'
@@ -1160,7 +1154,7 @@ Resources:
             - ';"RestoreModeSecParamName"='
             - !Sub '"${RestoreModeSecret}"'
             - ';"ExistingDomainController1IP"='
-            - !Sub '"${ExistingDomainController1IP}"'       
+            - !Sub '"${ExistingDomainController1IP}"'
             - ';"DomainDNSName"='
             - !Sub '"${DomainDNSName}"'
             - ';"DomainNetBIOSName"='

--- a/templates/ad-3.template
+++ b/templates/ad-3.template
@@ -1,16 +1,13 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >-
-  This template creates a managed Microsoft AD Directory Service into private subnets
-  in separate Availability Zones inside a VPC. The default Domain Administrator user
-  is 'admin'. For adding members to the domain, ensure that they are launched into
-  the domain member security group created by this template and then configure them
-  to use the AD instances fixed private IP addresses as the DNS server. **WARNING**
-  This template creates Amazon EC2 Windows instance and related resources. You will
-  be billed for the AWS resources used if you create a stack from this template. (qs-1qup6rad4)
+  This template creates a managed Microsoft AD Directory Service into private subnets in separate Availability Zones inside a VPC. The default Domain
+  Administrator user is 'admin'. For adding members to the domain, ensure that they are launched into the domain member security group created by this
+  template and then configure them to use the AD instances fixed private IP addresses as the DNS server. **WARNING** This template creates Amazon EC2
+  Windows instance and related resources. You will be billed for the AWS resources used if you create a stack from this template. (qs-1qup6rad4)
 Metadata:
   QuickStartDocumentation:
-    EntrypointName: "Launch AWS Managed Active Directory into an existing VPC"
-    Order: "5"
+    EntrypointName: 'Launch AWS Managed Active Directory into an existing VPC'
+    Order: '5'
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
@@ -48,7 +45,7 @@ Metadata:
           - EntCaServerNetBIOSName
           - CaKeyLength
           - CaHashAlgorithm
-          - OrCaValidityPeriodUnits          
+          - OrCaValidityPeriodUnits
           - CaValidityPeriodUnits
           - UseS3ForCRL
           - S3CRLBucketName
@@ -59,110 +56,67 @@ Metadata:
           - QSS3BucketRegion
           - QSS3KeyPrefix
     ParameterLabels:
-      VPCCIDR:
-        default: VPC CIDR
-      VPCID:
-        default: VPC ID
-      DHCPOptionSet:
-        default: Create a DHCP Options set 
-      PrivateSubnet1ID:
-        default: Subnet 1 ID
-      PrivateSubnet2ID:
-        default: Subnet 2 ID
-      DomainDNSName:
-        default: Domain DNS Name
-      DomainNetBIOSName:
-        default: Domain NetBIOS Name
-      DomainAdminPassword:
-        default: Admin Account Password
       ADEdition:
         default: AWS Microsoft AD Edition
-      MgmtServer:
-        default: Deploy Management Server
-      MgmtServerInstanceType:
-        default: Management Server Instance Type
-      MgmtAmi:
-        default: Management Server SSM Parameter Value for lastest AMI ID
-      MgmtDataDriveSizeGiB:
-        default: Data Drive Size
-      MgmtServerNetBIOSName:
-        default: Management Server NetBIOS Name
-      KeyPairName:
-        default: Key Pair Name
-      PKI:
-        default: CA Deployment Type
-      CaServerInstanceType:
-        default: CA Instance Type
       CaAmi:
         default: CA SSM Parameter Value for Lastest AMI ID
       CaDataDriveSizeGiB:
         default: CA Data Drive Size
-      OrCaServerNetBIOSName:
-        default: Offline Root CA NetBIOS Name (Only Used For Two Tier PKI)
-      EntCaServerNetBIOSName:
-        default: Enterprise Root or Subordinate CA NetBIOS Name
-      CaKeyLength:
-        default: CA Key Length
       CaHashAlgorithm:
         default: CA Hash Algorithm
-      OrCaValidityPeriodUnits:
-        default: Offline Root CA Certificate Validity Period in Years (Only Used For Two Tier PKI)
+      CaKeyLength:
+        default: CA Key Length
+      CaServerInstanceType:
+        default: CA Instance Type
       CaValidityPeriodUnits:
         default: Enterprise Root or Subordinate CA Certificate Validity Period in Years
-      UseS3ForCRL:
-        default: Use S3 for CA CRL Location
-      S3CRLBucketName:
-        default: CA CRL S3 Bucket Name
+      DHCPOptionSet:
+        default: Create a DHCP Options set
+      DomainAdminPassword:
+        default: Admin Account Password
+      DomainDNSName:
+        default: Domain DNS Name
+      DomainNetBIOSName:
+        default: Domain NetBIOS Name
+      EntCaServerNetBIOSName:
+        default: Enterprise Root or Subordinate CA NetBIOS Name
+      KeyPairName:
+        default: Key Pair Name
+      MgmtAmi:
+        default: Management Server SSM Parameter Value for lastest AMI ID
+      MgmtDataDriveSizeGiB:
+        default: Data Drive Size
+      MgmtServer:
+        default: Deploy Management Server
+      MgmtServerInstanceType:
+        default: Management Server Instance Type
+      MgmtServerNetBIOSName:
+        default: Management Server NetBIOS Name
+      OrCaServerNetBIOSName:
+        default: Offline Root CA NetBIOS Name (Only Used For Two Tier PKI)
+      OrCaValidityPeriodUnits:
+        default: Offline Root CA Certificate Validity Period in Years (Only Used For Two Tier PKI)
+      PKI:
+        default: CA Deployment Type
+      PrivateSubnet1ID:
+        default: Subnet 1 ID
+      PrivateSubnet2ID:
+        default: Subnet 2 ID
       QSS3BucketName:
         default: Quick Start S3 bucket name
       QSS3BucketRegion:
         default: Quick Start S3 bucket Region
       QSS3KeyPrefix:
         default: Quick Start S3 key prefix
+      S3CRLBucketName:
+        default: CA CRL S3 Bucket Name
+      UseS3ForCRL:
+        default: Use S3 for CA CRL Location
+      VPCCIDR:
+        default: VPC CIDR
+      VPCID:
+        default: VPC ID
 Parameters:
-  VPCCIDR:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
-    Default: 10.0.0.0/16
-    Description: CIDR Block for the VPC
-    Type: String
-  VPCID:
-    Description: ID of the VPC (e.g., vpc-0343606e)
-    Type: AWS::EC2::VPC::Id
-  DHCPOptionSet:
-    AllowedValues:
-      - 'Yes'
-      - 'No'
-    Default: 'Yes'
-    Description: Do you want to create and apply a new DHCP Options Set
-    Type: String
-  PrivateSubnet1ID:
-    Description: ID of  subnet 1 in Availability Zone 1 (e.g., subnet-a0246dcd)
-    Type: AWS::EC2::Subnet::Id
-  PrivateSubnet2ID:
-    Description: ID of subnet 2 in Availability Zone 2 (e.g., subnet-a0246dcd)
-    Type: AWS::EC2::Subnet::Id
-  DomainDNSName:
-    AllowedPattern: '[a-zA-Z0-9\-]+\..+'
-    Description: Fully qualified domain name (FQDN) of the forest root domain e.g. example.com
-    Type: String
-    Default: example.com
-    MinLength: '2'
-    MaxLength: '255'
-  DomainNetBIOSName:
-    AllowedPattern: '[a-zA-Z0-9\-]+'
-    Description: NetBIOS name of the domain (upto 15 characters) for users of earlier versions of Windows e.g. EXAMPLE
-    Type: String
-    Default: example
-    MinLength: '1'
-    MaxLength: '15'
-  DomainAdminPassword:
-    AllowedPattern: (?=^.{6,255}$)((?=.*\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*
-    Description: Password for the Admin user account. Must be at least 8 characters containing letters, numbers and symbols
-    NoEcho: 'true'
-    MinLength: '8'
-    MaxLength: '32'
-    Type: String
   ADEdition:
     AllowedValues:
       - Standard
@@ -170,6 +124,90 @@ Parameters:
     Default: Enterprise
     Description: The AWS Microsoft AD Edition you wish to deploy
     Type: String
+  CaAmi:
+    Default: /aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base
+    Description: Enterprise Root CA SSM Parameter Value to grab the latest AMI ID
+    Type: String
+  CaDataDriveSizeGiB:
+    Default: '2'
+    Description: Size of the data drive in GiB for the CA instance(s)
+    Type: Number
+  CaHashAlgorithm:
+    AllowedValues:
+      - SHA256
+      - SHA384
+      - SHA512
+    Default: SHA256
+    Description: CA(s) Hash Algorithm for Siging Certificates
+    Type: String
+  CaKeyLength:
+    AllowedValues:
+      - '2048'
+      - '4096'
+    Default: '2048'
+    Description: CA(s) Cryptographic Provider Key Length
+    Type: String
+  CaServerInstanceType:
+    AllowedValues:
+      - t2.small
+      - t3.small
+      - t2.medium
+      - t3.medium
+      - t2.large
+      - t3.large
+    Default: t3.medium
+    Description: Amazon EC2 instance type for the CA instance(s)
+    Type: String
+  CaValidityPeriodUnits:
+    Default: '5'
+    Description: Validity Period in Years
+    Type: String
+  DHCPOptionSet:
+    AllowedValues:
+      - 'Yes'
+      - 'No'
+    Default: 'Yes'
+    Description: Do you want to create and apply a new DHCP Options Set
+    Type: String
+  DomainAdminPassword:
+    AllowedPattern: (?=^.{6,255}$)((?=.*\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*
+    Description: Password for the Admin user account. Must be at least 8 characters containing letters, numbers and symbols
+    MaxLength: '32'
+    MinLength: '8'
+    NoEcho: 'true'
+    Type: String
+  DomainDNSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+\..+'
+    Default: example.com
+    Description: Fully qualified domain name (FQDN) of the forest root domain e.g. example.com
+    MaxLength: '255'
+    MinLength: '2'
+    Type: String
+  DomainNetBIOSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+'
+    Default: example
+    Description: NetBIOS name of the domain (upto 15 characters) for users of earlier versions of Windows e.g. EXAMPLE
+    MaxLength: '15'
+    MinLength: '1'
+    Type: String
+  EntCaServerNetBIOSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+'
+    Default: ENTCA1
+    Description: NetBIOS name of the Enterprise Root or Subordinate CA server (up to 15 characters)
+    MaxLength: '15'
+    MinLength: '1'
+    Type: String
+  KeyPairName:
+    Description: Public/private key pairs allow you to securely connect to your instance after it launches
+    Type: AWS::EC2::KeyPair::KeyName
+  MgmtAmi:
+    Default: '/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base'
+    Description: Management Server SSM Parameter Value to grab the lastest AMI ID
+    Type: String
+  MgmtDataDriveSizeGiB:
+    Default: '2'
+    Description: Size of the Managment Server Data Drive in GiB
+    Type: Number
   MgmtServer:
     AllowedValues:
       - 'true'
@@ -188,14 +226,6 @@ Parameters:
     Default: t3.medium
     Description: Amazon EC2 instance type for the Management Server
     Type: String
-  MgmtAmi:
-    Type: String
-    Description: Management Server  SSM Parameter Value to grab the lastest AMI ID
-    Default: '/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base'
-  MgmtDataDriveSizeGiB:
-    Default: '2'
-    Description: Size of the Managment Server Data Drive in GiB
-    Type: 'Number'
   MgmtServerNetBIOSName:
     AllowedPattern: '[a-zA-Z0-9\-]+'
     Default: MGMT1
@@ -203,37 +233,6 @@ Parameters:
     MaxLength: '15'
     MinLength: '1'
     Type: String
-  KeyPairName:
-    Description: Public/private key pairs allow you to securely connect to your instance
-      after it launches
-    Type: AWS::EC2::KeyPair::KeyName
-  PKI:
-    AllowedValues:
-      - 'One-Tier'
-      - 'Two-Tier'
-      - 'No'
-    Default: 'No'
-    Description: Deploy Two Tier (Offline Root with Subordinate Enterprise CA) or One Tier (Enterprise Root CA) PKI Infrastructure
-    Type: String
-  CaServerInstanceType:
-    AllowedValues:
-      - t2.small
-      - t3.small
-      - t2.medium
-      - t3.medium
-      - t2.large
-      - t3.large
-    Default: t3.medium
-    Description: Amazon EC2 instance type for the CA instance(s)
-    Type: String
-  CaAmi:
-    Description: Enterprise Root CA SSM Parameter Value to grab the lastest AMI ID
-    Default: '/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base'
-    Type: String
-  CaDataDriveSizeGiB:
-    Default: '2'
-    Description: Size of the data drive in GiB for the CA instance(s)
-    Type: 'Number'
   OrCaServerNetBIOSName:
     AllowedPattern: '[a-zA-Z0-9\-]+'
     Default: ORCA1
@@ -241,57 +240,32 @@ Parameters:
     MaxLength: '15'
     MinLength: '1'
     Type: String
-  EntCaServerNetBIOSName:
-    AllowedPattern: '[a-zA-Z0-9\-]+'
-    Default: ENTCA1
-    Description: NetBIOS name of the Enterprise Root or Subordinate CA server (up to 15 characters)
-    MaxLength: '15'
-    MinLength: '1'
-    Type: String
-  CaKeyLength:
-    Description: CA(s) Cryptographic Provider Key Length
-    AllowedValues:
-      - '2048'
-      - '4096'
-    Default: '2048'
-    Type: String
-  CaHashAlgorithm:
-    Description: CA(s) Hash Algorithm for Siging Certificates
-    AllowedValues:
-      - 'SHA256'
-      - 'SHA384'
-      - 'SHA512'
-    Default: 'SHA256'
-    Type: String
   OrCaValidityPeriodUnits:
-    Description: Validity Period in Years (Only Used For Two Tier PKI)
     Default: '10'
+    Description: Validity Period in Years (Only Used For Two Tier PKI)
     Type: String
-  CaValidityPeriodUnits:
-    Description: Validity Period in Years
-    Default: '5'
-    Type: String
-  UseS3ForCRL:
-    Description: Store CA CRL(s) in an S3 bucket
+  PKI:
     AllowedValues:
-      - 'Yes'
+      - One-Tier
+      - Two-Tier
       - 'No'
     Default: 'No'
+    Description: Deploy Two Tier (Offline Root with Subordinate Enterprise CA) or One Tier (Enterprise Root CA) PKI Infrastructure
     Type: String
-  S3CRLBucketName:
-    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
-    Default: examplebucket
-    Description: S3 bucket name for CA CRL(s) storage. Bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)
-    Type: String
+  PrivateSubnet1ID:
+    Description: ID of  subnet 1 in Availability Zone 1 (e.g., subnet-a0246dcd)
+    Type: AWS::EC2::Subnet::Id
+  PrivateSubnet2ID:
+    Description: ID of subnet 2 in Availability Zone 2 (e.g., subnet-a0246dcd)
+    Type: AWS::EC2::Subnet::Id
   QSS3BucketName:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
-    ConstraintDescription: Quick Start bucket name can include numbers, lowercase
-      letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen
-      (-).
+    ConstraintDescription:
+      Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
     Default: aws-quickstart
-    Description: S3 bucket name for the Quick Start assets. Quick Start bucket name
-      can include numbers, lowercase letters, uppercase letters, and hyphens (-)
-      It cannot start or end with a hyphen (-).
+    Description:
+      S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-) It
+      cannot start or end with a hyphen (-).
     Type: String
   QSS3BucketRegion:
     Default: us-east-1
@@ -301,8 +275,33 @@ Parameters:
     AllowedPattern: ^[0-9a-zA-Z-/]*$
     ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)
     Default: quickstart-microsoft-activedirectory/
-    Description: S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)
+    Description:
+      S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and
+      forward slash (/)
     Type: String
+  S3CRLBucketName:
+    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
+    Default: examplebucket
+    Description:
+      S3 bucket name for CA CRL(s) storage. Bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or
+      end with a hyphen (-)
+    Type: String
+  UseS3ForCRL:
+    AllowedValues:
+      - 'Yes'
+      - 'No'
+    Default: 'No'
+    Description: Store CA CRL(s) in an S3 bucket
+    Type: String
+  VPCCIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.0.0/16
+    Description: CIDR Block for the VPC
+    Type: String
+  VPCID:
+    Description: ID of the VPC (e.g., vpc-0343606e)
+    Type: AWS::EC2::VPC::Id
 Rules:
   SubnetsInVPC:
     Assertions:
@@ -314,26 +313,21 @@ Rules:
         AssertDescription: All subnets must in the VPC
   S3CRLBucketNameValidation:
     RuleCondition: !And
-      - !Equals
-        - !Ref UseS3ForCRL
-        - 'Yes'
-      - !Not 
-        - !Equals
-          - !Ref PKI
-          - 'No'
+      - !Equals [!Ref UseS3ForCRL, 'Yes']
+      - !Not [!Equals [!Ref PKI, 'No']]
     Assertions:
       - AssertDescription: CRL BucketName cannot must be valid BucketName
         Assert: !Not [!Equals [!Ref S3CRLBucketName, 'examplebucket']]
 Conditions:
-  UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
   ShouldCreateDHCPOption: !Not [!Equals [!Ref DHCPOptionSet, 'No']]
   ShouldCreateMgmtServer: !Equals [!Ref MgmtServer, 'true']
   ShouldCreateOneTierPkiResource: !Equals [!Ref PKI, 'One-Tier']
   ShouldCreateTwoTierPkiResource: !Equals [!Ref PKI, 'Two-Tier']
+  UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
 Resources:
   DHCPOptions:
-    Type: AWS::EC2::DHCPOptions
     Condition: ShouldCreateDHCPOption
+    Type: AWS::EC2::DHCPOptions
     Properties:
       DomainName: !Ref 'DomainDNSName'
       DomainNameServers: !GetAtt 'MicrosoftAD.DnsIpAddresses'
@@ -341,8 +335,8 @@ Resources:
         - Key: Domain
           Value: !Ref 'DomainDNSName'
   VPCDHCPOptionsAssociation:
-    Type: AWS::EC2::VPCDHCPOptionsAssociation
     Condition: ShouldCreateDHCPOption
+    Type: AWS::EC2::VPCDHCPOptionsAssociation
     Properties:
       VpcId: !Ref 'VPCID'
       DhcpOptionsId: !Ref 'DHCPOptions'
@@ -369,140 +363,132 @@ Resources:
     Properties:
       GroupDescription: Domain Members
       VpcId: !Ref 'VPCID'
+      Tags:
+        - Key: Name
+          Value: DomainMemberSG
   DomainMembersIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      Description: RDP 
+      Description: RDP
       GroupId: !Ref DomainMemberSG
-      IpProtocol: tcp 
-      FromPort: 3389 
+      IpProtocol: tcp
+      FromPort: 3389
       ToPort: 3389
       SourceSecurityGroupId: !Ref DomainMemberSG
   MgmtStack:
-    Type: AWS::CloudFormation::Stack
     Condition: ShouldCreateMgmtServer
+    Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL:
-        Fn::Sub:
-          - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/mgmt-1.template'
-          - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
-            S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+      TemplateURL: !Sub
+        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/mgmt-1.template'
+        - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+          S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
-        VPCCIDR: !Ref 'VPCCIDR'
-        VPCID: !Ref 'VPCID'
-        MgmtServerSubnet: !Ref 'PrivateSubnet1ID'
-        DomainMembersSG: !Ref 'DomainMemberSG'
-        MgmtServerInstanceType: !Ref 'MgmtServerInstanceType'
-        MgmtDataDriveSizeGiB: !Ref 'MgmtDataDriveSizeGiB'
-        KeyPairName: !Ref 'KeyPairName'
-        MgmtAmi: !Ref 'MgmtAmi'
         AdministratorSecret: !Ref 'ADAdminSecrets'
         DirectoryID: !Ref 'MicrosoftAD'
+        DomainController1IP: !Select ['0', !GetAtt 'MicrosoftAD.DnsIpAddresses']
+        DomainController2IP: !Select ['1', !GetAtt 'MicrosoftAD.DnsIpAddresses']
+        DomainDNSName: !Ref 'DomainDNSName'
+        DomainMembersSG: !Ref 'DomainMemberSG'
+        DomainNetBIOSName: !Ref 'DomainNetBIOSName'
+        KeyPairName: !Ref 'KeyPairName'
+        MgmtAmi: !Ref 'MgmtAmi'
+        MgmtDataDriveSizeGiB: !Ref 'MgmtDataDriveSizeGiB'
+        MgmtServerInstanceType: !Ref 'MgmtServerInstanceType'
         MgmtServerNetBIOSName: !Ref 'MgmtServerNetBIOSName'
-        DomainController1IP: !Select [ '0', !GetAtt 'MicrosoftAD.DnsIpAddresses' ]
-        DomainController2IP: !Select [ '1', !GetAtt 'MicrosoftAD.DnsIpAddresses' ]
-        DomainDNSName: !Ref 'DomainDNSName'     
-        DomainNetBIOSName: !Ref 'DomainNetBIOSName'       
+        MgmtServerSubnet: !Ref 'PrivateSubnet1ID'
         QSS3BucketName: !Ref 'QSS3BucketName'
         QSS3BucketRegion: !Ref 'QSS3BucketRegion'
         QSS3KeyPrefix: !Ref 'QSS3KeyPrefix'
+        VPCCIDR: !Ref 'VPCCIDR'
+        VPCID: !Ref 'VPCID'
   EntCAStack:
-    Type: AWS::CloudFormation::Stack
     Condition: ShouldCreateOneTierPkiResource
-    Properties:
-      TemplateURL:
-        Fn::Sub:
-          - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-microsoft-pki/templates/microsoft-pki.template.yaml'
-          - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
-            S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
-      Parameters:
-        VPCCIDR: !Ref 'VPCCIDR'
-        VPCID: !Ref 'VPCID'
-        CaServerSubnet: !Ref 'PrivateSubnet1ID'
-        DomainMembersSG: !Ref 'DomainMemberSG'
-        EntCaServerInstanceType: !Ref 'CaServerInstanceType'
-        EntCaDataDriveSizeGiB: !Ref 'CaDataDriveSizeGiB'
-        KeyPairName: !Ref 'KeyPairName'
-        AMI: !Ref 'CaAmi'
-        DomainDNSName: !Ref 'DomainDNSName'     
-        DomainNetBIOSName: !Ref 'DomainNetBIOSName'       
-        DomainController1IP: !Select [ '0', !GetAtt 'MicrosoftAD.DnsIpAddresses' ]
-        DomainController2IP: !Select [ '1', !GetAtt 'MicrosoftAD.DnsIpAddresses' ]
-        AdministratorSecret: !Ref 'ADAdminSecrets'
-        DirectoryType: 'AWSManaged'
-        CADeploymentType: 'One-Tier'
-        EntCaServerNetBIOSName: !Ref 'EntCaServerNetBIOSName'
-        CaKeyLength: !Ref 'CaKeyLength'
-        CaHashAlgorithm: !Ref 'CaHashAlgorithm'
-        CaValidityPeriodUnits: !Ref 'CaValidityPeriodUnits'
-        UseS3ForCRL: !Ref 'UseS3ForCRL'
-        S3CRLBucketName: !Ref 'S3CRLBucketName'
-        QSS3BucketName: !Ref 'QSS3BucketName'
-        QSS3BucketRegion: !Ref 'QSS3BucketRegion'
-        QSS3KeyPrefix: !Sub '${QSS3KeyPrefix}submodules/quickstart-microsoft-pki/'
-  TwoTierCAStack:
     Type: AWS::CloudFormation::Stack
-    Condition: ShouldCreateTwoTierPkiResource
     Properties:
-      TemplateURL:
-        Fn::Sub:
-          - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-microsoft-pki/templates/microsoft-pki.template.yaml'
-          - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
-            S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+      TemplateURL: !Sub
+        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-microsoft-pki/templates/one-tier.template'
+        - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+          S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
-        VPCCIDR: !Ref 'VPCCIDR'
-        VPCID: !Ref 'VPCID'
-        CaServerSubnet: !Ref 'PrivateSubnet1ID'
-        DomainMembersSG: !Ref 'DomainMemberSG'
-        OrCaServerInstanceType: !Ref 'CaServerInstanceType'
-        OrCaDataDriveSizeGiB: !Ref 'CaDataDriveSizeGiB'
-        EntCaServerInstanceType: !Ref 'CaServerInstanceType'
-        EntCaDataDriveSizeGiB: !Ref 'CaDataDriveSizeGiB'
-        KeyPairName: !Ref 'KeyPairName'
         AMI: !Ref 'CaAmi'
-        DomainDNSName: !Ref 'DomainDNSName'     
-        DomainNetBIOSName: !Ref 'DomainNetBIOSName'       
-        DomainController1IP: !Select [ '0', !GetAtt 'MicrosoftAD.DnsIpAddresses' ]
-        DomainController2IP: !Select [ '1', !GetAtt 'MicrosoftAD.DnsIpAddresses' ]
         AdministratorSecret: !Ref 'ADAdminSecrets'
         DirectoryType: 'AWSManaged'
-        CADeploymentType: 'Two-Tier'
-        OrCaServerNetBIOSName: !Ref 'OrCaServerNetBIOSName'
+        DomainController1IP: !Select ['0', !GetAtt 'MicrosoftAD.DnsIpAddresses']
+        DomainController2IP: !Select ['1', !GetAtt 'MicrosoftAD.DnsIpAddresses']
+        DomainDNSName: !Ref 'DomainDNSName'
+        DomainMembersSG: !Ref 'DomainMemberSG'
+        DomainNetBIOSName: !Ref 'DomainNetBIOSName'
+        EntCaDataDriveSizeGiB: !Ref 'CaDataDriveSizeGiB'
+        EntCaHashAlgorithm: !Ref 'CaHashAlgorithm'
+        EntCaKeyLength: !Ref 'CaKeyLength'
+        EntCaServerInstanceType: !Ref 'CaServerInstanceType'
         EntCaServerNetBIOSName: !Ref 'EntCaServerNetBIOSName'
-        CaKeyLength: !Ref 'CaKeyLength'
-        CaHashAlgorithm: !Ref 'CaHashAlgorithm'
-        OrCaValidityPeriodUnits: !Ref 'OrCaValidityPeriodUnits'
-        CaValidityPeriodUnits: !Ref 'CaValidityPeriodUnits'
-        UseS3ForCRL: !Ref 'UseS3ForCRL'
-        S3CRLBucketName: !Ref 'S3CRLBucketName'
+        EntCaServerSubnet: !Ref 'PrivateSubnet1ID'
+        EntCaValidityPeriodUnits: !Ref 'CaValidityPeriodUnits'
+        KeyPairName: !Ref 'KeyPairName'
         QSS3BucketName: !Ref 'QSS3BucketName'
         QSS3BucketRegion: !Ref 'QSS3BucketRegion'
         QSS3KeyPrefix: !Sub '${QSS3KeyPrefix}submodules/quickstart-microsoft-pki/'
+        S3CRLBucketName: !Ref 'S3CRLBucketName'
+        UseS3ForCRL: !Ref 'UseS3ForCRL'
+        VPCCIDR: !Ref 'VPCCIDR'
+        VPCID: !Ref 'VPCID'
+  TwoTierCAStack:
+    Condition: ShouldCreateTwoTierPkiResource
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub
+        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-microsoft-pki/templates/two-tier.template'
+        - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+          S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+      Parameters:
+        AMI: !Ref 'CaAmi'
+        AdministratorSecret: !Ref 'ADAdminSecrets'
+        DirectoryType: 'AWSManaged'
+        DomainController1IP: !Select ['0', !GetAtt 'MicrosoftAD.DnsIpAddresses']
+        DomainController2IP: !Select ['1', !GetAtt 'MicrosoftAD.DnsIpAddresses']
+        DomainDNSName: !Ref 'DomainDNSName'
+        DomainMembersSG: !Ref 'DomainMemberSG'
+        DomainNetBIOSName: !Ref 'DomainNetBIOSName'
+        KeyPairName: !Ref 'KeyPairName'
+        OrCaDataDriveSizeGiB: !Ref 'CaDataDriveSizeGiB'
+        OrCaHashAlgorithm: !Ref 'CaHashAlgorithm'
+        OrCaKeyLength: !Ref 'CaKeyLength'
+        OrCaServerInstanceType: !Ref 'CaServerInstanceType'
+        OrCaServerNetBIOSName: !Ref 'OrCaServerNetBIOSName'
+        OrCaServerSubnet: !Ref 'PrivateSubnet1ID'
+        OrCaValidityPeriodUnits: !Ref 'OrCaValidityPeriodUnits'
+        QSS3BucketName: !Ref 'QSS3BucketName'
+        QSS3BucketRegion: !Ref 'QSS3BucketRegion'
+        QSS3KeyPrefix: !Sub '${QSS3KeyPrefix}submodules/quickstart-microsoft-pki/'
+        S3CRLBucketName: !Ref 'S3CRLBucketName'
+        SubCaDataDriveSizeGiB: !Ref 'CaDataDriveSizeGiB'
+        SubCaHashAlgorithm: !Ref 'CaHashAlgorithm'
+        SubCaKeyLength: !Ref 'CaKeyLength'
+        SubCaServerInstanceType: !Ref 'CaServerInstanceType'
+        SubCaServerNetBIOSName: !Ref 'EntCaServerNetBIOSName'
+        SubCaServerSubnet: !Ref 'PrivateSubnet1ID'
+        SubCaValidityPeriodUnits: !Ref 'CaValidityPeriodUnits'
+        UseS3ForCRL: !Ref 'UseS3ForCRL'
+        VPCCIDR: !Ref 'VPCCIDR'
+        VPCID: !Ref 'VPCID'
 Outputs:
-  ADServer1PrivateIP:
-    Value: !Select
-      - '0'
-      - !GetAtt 'MicrosoftAD.DnsIpAddresses'
-    Description: AD Server 1 Private IP Address (this may vary based on Directory
-      Service order of IP addresses)
-  ADServer2PrivateIP:
-    Value: !Select
-      - '1'
-      - !GetAtt 'MicrosoftAD.DnsIpAddresses'
-    Description: AD Server 2 Private IP Address (this may vary based on Directory
-      Service order of IP addresses)
-  DirectoryID:
-    Value: !Ref 'MicrosoftAD'
-    Description: Directory Services ID
-  DomainAdmin:
-    Value: !Join
-      - ''
-      - - !Ref 'DomainNetBIOSName'
-        - \admin
-    Description: Domain administrator account
-  DomainMemberSGID:
-    Value: !Ref 'DomainMemberSG'
-    Description: Domain Member Security Group ID
   ADSecretsArn:
-    Value: !Ref 'ADAdminSecrets'
     Description: Managed AD Admin Secrets
+    Value: !Ref 'ADAdminSecrets'
+  ADServer1PrivateIP:
+    Description: AD Server 1 Private IP Address (this may vary based on Directory Service order of IP addresses)
+    Value: !Select ['0', !GetAtt 'MicrosoftAD.DnsIpAddresses']
+  ADServer2PrivateIP:
+    Description: AD Server 2 Private IP Address (this may vary based on Directory Service order of IP addresses)
+    Value: !Select ['1', !GetAtt 'MicrosoftAD.DnsIpAddresses']
+  DirectoryID:
+    Description: Directory Services ID
+    Value: !Ref 'MicrosoftAD'
+  DomainAdmin:
+    Description: Domain administrator account
+    Value: !Sub ${DomainNetBIOSName}\admin
+  DomainMemberSGID:
+    Description: Domain Member Security Group ID
+    Value: !Ref 'DomainMemberSG'

--- a/templates/ad-master-1.template
+++ b/templates/ad-master-1.template
@@ -1,20 +1,15 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >-
-  This template creates a VPC infrastructure for a multi-AZ, multi-tier
-  deployment of a Windows based Application infrastructure. It installs 2 Windows
-  2019 Active Directory Domain Controllers into private subnets in separate Availability
-  Zones inside a VPC, as well as Remote Desktop Gateway instances and managed NAT
-  gateways into the public subnet for each Availability Zone. The default Domain Administrator
-  password will be the one retrieved from the instance.  For adding members to the
-  domain, ensure that they are launched into the domain member security group created
-  by this template and then configure them to use the AD instances fixed private IP
-  addresses as the DNS server. **WARNING** This template creates Amazon EC2 Windows
-  instance and related resources. You will be billed for the AWS resources used if
-  you create a stack from this template.
+  This template creates a VPC infrastructure for a multi-AZ, multi-tier deployment of a Windows based Application infrastructure. It installs 2
+  Windows 2019 Active Directory Domain Controllers into private subnets in separate Availability Zones inside a VPC, as well as Remote Desktop Gateway
+  instances and managed NAT gateways into the public subnet for each Availability Zone. The default Domain Administrator password will be the one
+  retrieved from the instance.  For adding members to the domain, ensure that they are launched into the domain member security group created by this
+  template and then configure them to use the AD instances fixed private IP addresses as the DNS server. **WARNING** This template creates Amazon EC2
+  Windows instance and related resources. You will be billed for the AWS resources used if you create a stack from this template.
 Metadata:
   QuickStartDocumentation:
-    EntrypointName: "Launch Active Directory on EC2 into a new VPC"
-    Order: "1"
+    EntrypointName: 'Launch Active Directory on EC2 into a new VPC'
+    Order: '1'
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
@@ -78,26 +73,6 @@ Metadata:
           - QSS3BucketRegion
           - QSS3KeyPrefix
     ParameterLabels:
-      NumberOfAZs:
-        default: Number of Availability Zones
-      AvailabilityZones:
-        default: Availability Zones
-      VPCCIDR:
-        default: VPC CIDR
-      DHCPOptionSet:
-        default: Create a DHCP Options set 
-      PrivateSubnet1CIDR:
-        default: Private Subnet 1 CIDR
-      PrivateSubnet2CIDR:
-        default: Private Subnet 2 CIDR
-      PrivateSubnet3CIDR:
-        default: (Optional) Private Subnet 3 CIDR
-      PublicSubnet1CIDR:
-        default: Public Subnet 1 CIDR
-      PublicSubnet2CIDR:
-        default: Public Subnet 2 CIDR
-      PublicSubnet3CIDR:
-        default: (Optional) Public Subnet 3 CIDR
       ADServer1InstanceType:
         default: Domain Controller 1 Instance Type
       ADServer1NetBIOSName:
@@ -110,114 +85,79 @@ Metadata:
         default: Domain Controller 2 NetBIOS Name
       ADServer2PrivateIP:
         default: Domain Controller 2 Private IP Address
+      AvailabilityZones:
+        default: Availability Zones
+      CaDataDriveSizeGiB:
+        default: CA Data Drive Size
+      CaHashAlgorithm:
+        default: CA Hash Algorithm
+      CaKeyLength:
+        default: CA Key Length
+      CaServerInstanceType:
+        default: CA Instance Type
+      CaValidityPeriodUnits:
+        default: Enterprise Root or Subordinate CA Certificate Validity Period in Years
+      CreateDefaultOUs:
+        default: Create Default OUs
+      DHCPOptionSet:
+        default: Create a DHCP Options set
       DataDriveSizeGiB:
         default: SYSVOL and NTDS and Data Drive Size
-      KeyPairName:
-        default: Key Pair Name
-      DomainAdminUser:
-        default: Alternate Domain Admin User Name
+      DeletedObjectLifetime:
+        default: Set new Deleted Objects Lifetime
       DomainAdminPassword:
         default: Alternate Domain Admin Password
+      DomainAdminUser:
+        default: Alternate Domain Admin User Name
       DomainDNSName:
         default: Domain DNS Name
       DomainNetBIOSName:
         default: Domain NetBIOS Name
-      CreateDefaultOUs:
-        default: Create Default OUs
-      TombstoneLifetime:
-        default: Set new Tombstone Lifetime
-      DeletedObjectLifetime:
-        default: Set new Deleted Objects Lifetime
-      PKI:
-        default: Deploy PKI Infrastructure
-      CaServerInstanceType:
-        default: CA Instance Type
-      CaDataDriveSizeGiB:
-        default: CA Data Drive Size
-      OrCaServerNetBIOSName:
-        default: Offline Root CA NetBIOS Name (Only Used For Two Tier PKI)
       EntCaServerNetBIOSName:
         default: Enterprise Root or Subordinate CA NetBIOS Name
-      CaKeyLength:
-        default: CA Key Length
-      CaHashAlgorithm:
-        default: CA Hash Algorithm
-      OrCaValidityPeriodUnits:
-        default: Offline Root CA Certificate Validity Period in Years (Only Used For Two Tier PKI)
-      CaValidityPeriodUnits:
-        default: Enterprise Root or Subordinate CA Certificate Validity Period in Years
-      UseS3ForCRL:
-        default: Use S3 for CA CRL Location
-      S3CRLBucketName:
-        default: CA CRL S3 Bucket Name
+      KeyPairName:
+        default: Key Pair Name
+      NumberOfAZs:
+        default: Number of Availability Zones
       NumberOfRDGWHosts:
         default: Number of RDGW Hosts
-      RDGWInstanceType:
-        default: Remote Desktop Gateway Instance Type
-      RDGWCIDR:
-        default: Allowed Remote Desktop Gateway External Access CIDR
+      OrCaServerNetBIOSName:
+        default: Offline Root CA NetBIOS Name (Only Used For Two Tier PKI)
+      OrCaValidityPeriodUnits:
+        default: Offline Root CA Certificate Validity Period in Years (Only Used For Two Tier PKI)
+      PKI:
+        default: Deploy PKI Infrastructure
+      PrivateSubnet1CIDR:
+        default: Private Subnet 1 CIDR
+      PrivateSubnet2CIDR:
+        default: Private Subnet 2 CIDR
+      PrivateSubnet3CIDR:
+        default: (Optional) Private Subnet 3 CIDR
+      PublicSubnet1CIDR:
+        default: Public Subnet 1 CIDR
+      PublicSubnet2CIDR:
+        default: Public Subnet 2 CIDR
+      PublicSubnet3CIDR:
+        default: (Optional) Public Subnet 3 CIDR
       QSS3BucketName:
         default: Quick Start S3 Bucket Name
       QSS3BucketRegion:
         default: Quick Start S3 Bucket Region
       QSS3KeyPrefix:
         default: Quick Start S3 Key Prefix
+      RDGWCIDR:
+        default: Allowed Remote Desktop Gateway External Access CIDR
+      RDGWInstanceType:
+        default: Remote Desktop Gateway Instance Type
+      S3CRLBucketName:
+        default: CA CRL S3 Bucket Name
+      TombstoneLifetime:
+        default: Set new Tombstone Lifetime
+      UseS3ForCRL:
+        default: Use S3 for CA CRL Location
+      VPCCIDR:
+        default: VPC CIDR
 Parameters:
-  AvailabilityZones:
-    Description: 'List of Availability Zones to use for the subnets in the VPC. Note: The logical order is preserved and only 2 AZs are used for this deployment'
-    Type: List<AWS::EC2::AvailabilityZone::Name>
-  NumberOfAZs:
-    AllowedValues:
-      - '2'
-      - '3'
-    Default: '2'
-    Description: Number of Availability Zones to use in the VPC. This must match your selections in the list of Availability Zones parameter
-    Type: String
-  VPCCIDR:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
-    Default: 10.0.0.0/16
-    Description: CIDR Block for the VPC
-    Type: String
-  DHCPOptionSet:
-    AllowedValues:
-      - 'Yes'
-      - 'No'
-    Default: 'Yes'
-    Description: Do you want to create and apply a new DHCP Options Set
-    Type: String
-  PrivateSubnet1CIDR:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
-    Default: 10.0.0.0/19
-    Description: CIDR block for private subnet 1 located in Availability Zone 1
-    Type: String
-  PrivateSubnet2CIDR:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
-    Default: 10.0.32.0/19
-    Description: CIDR block for private subnet 2 located in Availability Zone 2
-    Type: String
-  PrivateSubnet3CIDR:
-    Default: ''
-    Description: CIDR block for private subnet 3 located in Availability Zone 3
-    Type: String
-  PublicSubnet1CIDR:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
-    Default: 10.0.128.0/20
-    Description: CIDR Block for the public subnet 1 located in Availability Zone 1
-    Type: String
-  PublicSubnet2CIDR:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
-    Default: 10.0.144.0/20
-    Description: CIDR Block for the public subnet 2 located in Availability Zone 2
-    Type: String
-  PublicSubnet3CIDR:
-    Default: ''
-    Description: CIDR Block for the public subnet 3 located in Availability Zone 3
-    Type: String
   ADServer1InstanceType:
     AllowedValues:
       - t2.medium
@@ -274,29 +214,83 @@ Parameters:
   ADServer2PrivateIP:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
     Default: 10.0.32.10
-    Description: Fixed private IP for the second Active Directory Domain Controller located in Availability Zone 2
-      Availability Zone 2
+    Description: Fixed private IP for the second Active Directory Domain Controller located in Availability Zone 2 Availability Zone 2
+    Type: String
+  AvailabilityZones:
+    Description:
+      'List of Availability Zones to use for the subnets in the VPC. Note: The logical order is preserved and only 2 AZs are used for this deployment'
+    Type: List<AWS::EC2::AvailabilityZone::Name>
+  CaDataDriveSizeGiB:
+    Default: '2'
+    Description: Size of the data drive in GiB for the CA instance(s)
+    Type: Number
+  CaHashAlgorithm:
+    AllowedValues:
+      - SHA256
+      - SHA384
+      - SHA512
+    Default: SHA256
+    Description: CA(s) Hash Algorithm for Siging Certificates
+    Type: String
+  CaKeyLength:
+    AllowedValues:
+      - '2048'
+      - '4096'
+    Default: '2048'
+    Description: CA(s) Cryptographic Provider Key Length
+    Type: String
+  CaServerInstanceType:
+    AllowedValues:
+      - t2.small
+      - t3.small
+      - t2.medium
+      - t3.medium
+      - t2.large
+      - t3.large
+    Default: t3.medium
+    Description: Amazon EC2 instance type for the CA instance(s)
+    Type: String
+  CaValidityPeriodUnits:
+    Default: '5'
+    Description: Validity Period in Years
+    Type: String
+  CreateDefaultOUs:
+    AllowedValues:
+      - 'Yes'
+      - 'No'
+    Default: 'No'
+    Description:
+      Domain Elevated Accounts, Domain Users, Domain Computers, Domain Servers, Domain Service Accounts, and Domain Groups OUs and set the default
+      users and computers containers to Domain Users and Domain Computers
+    Type: String
+  DHCPOptionSet:
+    AllowedValues:
+      - 'Yes'
+      - 'No'
+    Default: 'Yes'
+    Description: Do you want to create and apply a new DHCP Options Set
     Type: String
   DataDriveSizeGiB:
     Default: '10'
     Description: Size of SYSVOL and NTDS data drive in GiB
-    Type: 'Number'
-  KeyPairName:
-    Description: Public/private key pairs allow you to securely connect to your instance after it launches
-    Type: AWS::EC2::KeyPair::KeyName
-  DomainAdminUser:
-    AllowedPattern: '[a-zA-Z0-9]*'
-    Default: Admin
-    Description: User name for the account that will be added as a Domain Administrator. This is separate from the default "Administrator" account
-    MaxLength: '25'
-    MinLength: '5'
-    Type: String
+    Type: Number
+  DeletedObjectLifetime:
+    Default: '180'
+    Description: The number of days before a deleted object is removed from the Active Directory recycling bin, minimum number is 2
+    Type: Number
   DomainAdminPassword:
     AllowedPattern: (?=^.{6,255}$)((?=.*\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*
     Description: Password for the account named above. Must be at least 8 characters containing letters, numbers and symbols
     MaxLength: '32'
     MinLength: '8'
     NoEcho: 'true'
+    Type: String
+  DomainAdminUser:
+    AllowedPattern: '[a-zA-Z0-9]*'
+    Default: Admin
+    Description: User name for the account that will be added as a Domain Administrator. This is separate from the default "Administrator" account
+    MaxLength: '25'
+    MinLength: '5'
     Type: String
   DomainDNSName:
     AllowedPattern: '[a-zA-Z0-9\-]+\..+'
@@ -312,51 +306,6 @@ Parameters:
     MaxLength: '15'
     MinLength: '1'
     Type: String
-  CreateDefaultOUs:
-    AllowedValues:
-      - 'Yes'
-      - 'No'
-    Default: 'No'
-    Description: Domain Elevated Accounts, Domain Users, Domain Computers, Domain Servers, Domain Service Accounts, and Domain Groups OUs and set the default users and computers containers to Domain Users and Domain Computers
-    Type: String
-  TombstoneLifetime:
-    Default: '180'
-    Description: The number of days before a deleted object is removed from Active Directory, minimum number is 2
-    Type: 'Number'
-  DeletedObjectLifetime:
-    Default: '180'
-    Description: The number of days before a deleted object is removed from the Active Directory recycling bin, minimum number is 2
-    Type: 'Number'
-  PKI:
-    AllowedValues:
-      - 'One-Tier'
-      - 'Two-Tier'
-      - 'No'
-    Default: 'No'
-    Description: Deploy Two Tier (Offline Root with Subordinate Enterprise CA) or One Tier (Enterprise Root CA) PKI Infrastructure
-    Type: String
-  CaServerInstanceType:
-    AllowedValues:
-      - t2.small
-      - t3.small
-      - t2.medium
-      - t3.medium
-      - t2.large
-      - t3.large
-    Default: t3.medium
-    Description: Amazon EC2 instance type for the CA instance(s)
-    Type: String
-  CaDataDriveSizeGiB:
-    Default: '2'
-    Description: Size of the data drive in GiB for the CA instance(s)
-    Type: 'Number'
-  OrCaServerNetBIOSName:
-    AllowedPattern: '[a-zA-Z0-9\-]+'
-    Default: ORCA1
-    Description: NetBIOS name of the Offline Root CA server (Only Used For Two Tier PKI) (up to 15 characters)
-    MaxLength: '15'
-    MinLength: '1'
-    Type: String
   EntCaServerNetBIOSName:
     AllowedPattern: '[a-zA-Z0-9\-]+'
     Default: ENTCA1
@@ -364,40 +313,15 @@ Parameters:
     MaxLength: '15'
     MinLength: '1'
     Type: String
-  CaKeyLength:
-    Description: CA(s) Cryptographic Provider Key Length
+  KeyPairName:
+    Description: Public/private key pairs allow you to securely connect to your instance after it launches
+    Type: AWS::EC2::KeyPair::KeyName
+  NumberOfAZs:
     AllowedValues:
-      - '2048'
-      - '4096'
-    Default: '2048'
-    Type: String
-  CaHashAlgorithm:
-    Description: CA(s) Hash Algorithm for Siging Certificates
-    AllowedValues:
-      - 'SHA256'
-      - 'SHA384'
-      - 'SHA512'
-    Default: 'SHA256'
-    Type: String
-  OrCaValidityPeriodUnits:
-    Description: Validity Period in Years (Only Used For Two Tier PKI)
-    Default: '10'
-    Type: String
-  CaValidityPeriodUnits:
-    Description: Validity Period in Years
-    Default: '5'
-    Type: String
-  UseS3ForCRL:
-    Description: Store CA CRL(s) in an S3 bucket    
-    AllowedValues:
-      - 'Yes'
-      - 'No'
-    Default: 'No'
-    Type: String
-  S3CRLBucketName:
-    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
-    Default: examplebucket
-    Description: S3 bucket name for CA CRL(s) storage. Bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)
+      - '2'
+      - '3'
+    Default: '2'
+    Description: Number of Availability Zones to use in the VPC. This must match your selections in the list of Availability Zones parameter
     Type: String
   NumberOfRDGWHosts:
     AllowedValues:
@@ -408,6 +332,83 @@ Parameters:
       - '4'
     Default: '1'
     Description: Enter the number of Remote Desktop Gateway instances to create
+    Type: String
+  OrCaServerNetBIOSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+'
+    Default: ORCA1
+    Description: NetBIOS name of the Offline Root CA server (Only Used For Two Tier PKI) (up to 15 characters)
+    MaxLength: '15'
+    MinLength: '1'
+    Type: String
+  OrCaValidityPeriodUnits:
+    Default: '10'
+    Description: Validity Period in Years (Only Used For Two Tier PKI)
+    Type: String
+  PKI:
+    AllowedValues:
+      - One-Tier
+      - Two-Tier
+      - 'No'
+    Default: 'No'
+    Description: Deploy Two Tier (Offline Root with Subordinate Enterprise CA) or One Tier (Enterprise Root CA) PKI Infrastructure
+    Type: String
+  PrivateSubnet1CIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.0.0/19
+    Description: CIDR block for private subnet 1 located in Availability Zone 1
+    Type: String
+  PrivateSubnet2CIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.32.0/19
+    Description: CIDR block for private subnet 2 located in Availability Zone 2
+    Type: String
+  PrivateSubnet3CIDR:
+    Default: ''
+    Description: CIDR block for private subnet 3 located in Availability Zone 3
+    Type: String
+  PublicSubnet1CIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.128.0/20
+    Description: CIDR Block for the public subnet 1 located in Availability Zone 1
+    Type: String
+  PublicSubnet2CIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.144.0/20
+    Description: CIDR Block for the public subnet 2 located in Availability Zone 2
+    Type: String
+  PublicSubnet3CIDR:
+    Default: ''
+    Description: CIDR Block for the public subnet 3 located in Availability Zone 3
+    Type: String
+  QSS3BucketName:
+    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
+    ConstraintDescription:
+      Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)
+    Default: aws-quickstart
+    Description:
+      S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-).
+      It cannot start or end with a hyphen (-)
+    Type: String
+  QSS3BucketRegion:
+    Default: us-east-1
+    Description: The AWS Region where the Quick Start S3 bucket (QSS3BucketName) is hosted. When using your own bucket, you must specify this value
+    Type: String
+  QSS3KeyPrefix:
+    AllowedPattern: ^[0-9a-zA-Z-/]*$
+    ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)
+    Default: quickstart-microsoft-activedirectory/
+    Description:
+      S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and
+      forward slash (/)
+    Type: String
+  RDGWCIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
+    Description: Allowed CIDR Block for external access to the Remote Desktop Gateways
     Type: String
   RDGWInstanceType:
     AllowedValues:
@@ -421,162 +422,121 @@ Parameters:
       - m5.xlarge
       - m5.2xlarge
       - m5.4xlarge
-    Description: Amazon EC2 instance type for the Remote Desktop Gateway instances
     Default: t3.large
+    Description: Amazon EC2 instance type for the Remote Desktop Gateway instances
     Type: String
-  RDGWCIDR:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
-    Description: Allowed CIDR Block for external access to the Remote Desktop Gateways
-    Type: String
-  QSS3BucketName:
+  S3CRLBucketName:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
-    ConstraintDescription: Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)
-    Default: aws-quickstart
-    Description: S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)
+    Default: examplebucket
+    Description:
+      S3 bucket name for CA CRL(s) storage. Bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or
+      end with a hyphen (-)
     Type: String
-  QSS3BucketRegion:
-    Default: us-east-1
-    Description: The AWS Region where the Quick Start S3 bucket (QSS3BucketName) is hosted. When using your own bucket, you must specify this value
+  TombstoneLifetime:
+    Default: '180'
+    Description: The number of days before a deleted object is removed from Active Directory, minimum number is 2
+    Type: Number
+  UseS3ForCRL:
+    AllowedValues:
+      - 'Yes'
+      - 'No'
+    Default: 'No'
+    Description: Store CA CRL(s) in an S3 bucket
     Type: String
-  QSS3KeyPrefix:
-    AllowedPattern: ^[0-9a-zA-Z-/]*$
-    ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)
-    Default: quickstart-microsoft-activedirectory/
-    Description: S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)
+  VPCCIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.0.0/16
+    Description: CIDR Block for the VPC
     Type: String
 Conditions:
-  IsTwoAz: !Equals
-    - !Ref 'NumberOfAZs'
-    - '2'
+  IncludeRDGW: !Not [!Equals [!Ref NumberOfRDGWHosts, '0']]
+  IsTwoAz: !Equals [!Ref 'NumberOfAZs', '2']
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
-  IncludeRDGW: !Not
-    - !Equals
-      - !Ref NumberOfRDGWHosts
-      - '0'
 Rules:
   CheckSupportedInstances:
-    RuleCondition: !Or [!Contains [[m4.large, m4.xlarge, m4.2xlarge, m4.4xlarge],
-        !Ref 'ADServer1InstanceType'], !Contains [[m4.large, m4.xlarge, m4.2xlarge,
-          m4.4xlarge], !Ref 'ADServer2InstanceType']]
+    RuleCondition: !Or
+      - !Contains [[m4.large, m4.xlarge, m4.2xlarge, m4.4xlarge], !Ref 'ADServer1InstanceType']
+      - !Contains [[m4.large, m4.xlarge, m4.2xlarge, m4.4xlarge], !Ref 'ADServer2InstanceType']
     Assertions:
       - Assert: !Not [!Contains [[eu-west-3], !Ref 'AWS::Region']]
         AssertDescription: M4 instances are not available in the Paris region
   S3CRLBucketNameValidation:
     RuleCondition: !And
-      - !Equals
-        - !Ref UseS3ForCRL
-        - 'Yes'
-      - !Not 
-        - !Equals
-          - !Ref PKI
-          - 'No'
+      - !Equals [!Ref UseS3ForCRL, 'Yes']
+      - !Not [!Equals [!Ref PKI, 'No']]
     Assertions:
       - AssertDescription: CRL BucketName cannot must be valid BucketName
         Assert: !Not [!Equals [!Ref S3CRLBucketName, 'examplebucket']]
 Resources:
   VPCStack:
-      Type: AWS::CloudFormation::Stack
-      Properties:
-        TemplateURL:
-          Fn::Sub:
-            - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template'
-            - S3Region: !If
-                - UsingDefaultBucket
-                - !Ref AWS::Region
-                - !Ref QSS3BucketRegion
-              S3Bucket: !If
-                - UsingDefaultBucket
-                - !Sub '${QSS3BucketName}-${AWS::Region}'
-                - !Ref QSS3BucketName
-        Parameters:
-          AvailabilityZones: !Join
-            - ','
-            - !Ref 'AvailabilityZones'
-          KeyPairName: !Ref 'KeyPairName'
-          NumberOfAZs: !If
-            - IsTwoAz
-            - '2'
-            - '3'
-          PrivateSubnet1ACIDR: !Ref 'PrivateSubnet1CIDR'
-          PrivateSubnet2ACIDR: !Ref 'PrivateSubnet2CIDR'
-          PrivateSubnet3ACIDR: !If
-            - IsTwoAz
-            - !Ref 'AWS::NoValue'
-            - !Ref 'PrivateSubnet3CIDR'
-          PublicSubnet1CIDR: !Ref 'PublicSubnet1CIDR'
-          PublicSubnet2CIDR: !Ref 'PublicSubnet2CIDR'
-          PublicSubnet3CIDR: !If
-            - IsTwoAz
-            - !Ref 'AWS::NoValue'
-            - !Ref 'PublicSubnet3CIDR'
-          VPCCIDR: !Ref 'VPCCIDR'
-  ADStack:
-    DependsOn: VPCStack
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL:
-        Fn::Sub:
-          - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/ad-1.template'
-          - S3Region: !If
-              - UsingDefaultBucket
-              - !Ref AWS::Region
-              - !Ref QSS3BucketRegion
-            S3Bucket: !If
-              - UsingDefaultBucket
-              - !Sub '${QSS3BucketName}-${AWS::Region}'
-              - !Ref QSS3BucketName
+      TemplateURL: !Sub
+        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template'
+        - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+          S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
+        AvailabilityZones: !Join [',', !Ref 'AvailabilityZones']
+        KeyPairName: !Ref 'KeyPairName'
+        NumberOfAZs: !If [IsTwoAz, '2', '3']
+        PrivateSubnet1ACIDR: !Ref 'PrivateSubnet1CIDR'
+        PrivateSubnet2ACIDR: !Ref 'PrivateSubnet2CIDR'
+        PrivateSubnet3ACIDR: !If [IsTwoAz, !Ref 'AWS::NoValue', !Ref 'PrivateSubnet3CIDR']
+        PublicSubnet1CIDR: !Ref 'PublicSubnet1CIDR'
+        PublicSubnet2CIDR: !Ref 'PublicSubnet2CIDR'
+        PublicSubnet3CIDR: !If [IsTwoAz, !Ref 'AWS::NoValue', !Ref 'PublicSubnet3CIDR']
         VPCCIDR: !Ref 'VPCCIDR'
-        VPCID: !GetAtt 'VPCStack.Outputs.VPCID'
-        DHCPOptionSet: !Ref 'DHCPOptionSet'
-        PrivateSubnet1ID: !GetAtt 'VPCStack.Outputs.PrivateSubnet1AID'
-        PrivateSubnet2ID: !GetAtt 'VPCStack.Outputs.PrivateSubnet2AID'
+  ADStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub
+        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/ad-1.template'
+        - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+          S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+      Parameters:
         ADServer1InstanceType: !Ref 'ADServer1InstanceType'
         ADServer1NetBIOSName: !Ref 'ADServer1NetBIOSName'
         ADServer1PrivateIP: !Ref 'ADServer1PrivateIP'
         ADServer2InstanceType: !Ref 'ADServer2InstanceType'
         ADServer2NetBIOSName: !Ref 'ADServer2NetBIOSName'
         ADServer2PrivateIP: !Ref 'ADServer2PrivateIP'
+        CaDataDriveSizeGiB: !Ref 'CaDataDriveSizeGiB'
+        CaHashAlgorithm: !Ref 'CaHashAlgorithm'
+        CaKeyLength: !Ref 'CaKeyLength'
+        CaServerInstanceType: !Ref 'CaServerInstanceType'
+        CaValidityPeriodUnits: !Ref 'CaValidityPeriodUnits'
+        CreateDefaultOUs: !Ref 'CreateDefaultOUs'
+        DHCPOptionSet: !Ref 'DHCPOptionSet'
         DataDriveSizeGiB: !Ref 'DataDriveSizeGiB'
-        KeyPairName: !Ref 'KeyPairName'
-        DomainAdminUser: !Ref 'DomainAdminUser'    
+        DeletedObjectLifetime: !Ref 'DeletedObjectLifetime'
         DomainAdminPassword: !Ref 'DomainAdminPassword'
+        DomainAdminUser: !Ref 'DomainAdminUser'
         DomainDNSName: !Ref 'DomainDNSName'
         DomainNetBIOSName: !Ref 'DomainNetBIOSName'
-        CreateDefaultOUs: !Ref 'CreateDefaultOUs'
-        TombstoneLifetime: !Ref 'TombstoneLifetime'
-        DeletedObjectLifetime: !Ref 'DeletedObjectLifetime'
-        PKI: !Ref 'PKI'
-        CaServerInstanceType: !Ref 'CaServerInstanceType'
-        CaDataDriveSizeGiB: !Ref 'CaDataDriveSizeGiB'
-        OrCaServerNetBIOSName: !Ref 'OrCaServerNetBIOSName'
         EntCaServerNetBIOSName: !Ref 'EntCaServerNetBIOSName'
-        CaKeyLength: !Ref 'CaKeyLength'
-        CaHashAlgorithm: !Ref 'CaHashAlgorithm'
+        KeyPairName: !Ref 'KeyPairName'
+        OrCaServerNetBIOSName: !Ref 'OrCaServerNetBIOSName'
         OrCaValidityPeriodUnits: !Ref 'OrCaValidityPeriodUnits'
-        CaValidityPeriodUnits: !Ref 'CaValidityPeriodUnits'
-        UseS3ForCRL: !Ref 'UseS3ForCRL'
-        S3CRLBucketName: !Ref 'S3CRLBucketName'
+        PKI: !Ref 'PKI'
+        PrivateSubnet1ID: !GetAtt 'VPCStack.Outputs.PrivateSubnet1AID'
+        PrivateSubnet2ID: !GetAtt 'VPCStack.Outputs.PrivateSubnet2AID'
         QSS3BucketName: !Ref 'QSS3BucketName'
         QSS3BucketRegion: !Ref 'QSS3BucketRegion'
         QSS3KeyPrefix: !Ref 'QSS3KeyPrefix'
+        S3CRLBucketName: !Ref 'S3CRLBucketName'
+        TombstoneLifetime: !Ref 'TombstoneLifetime'
+        UseS3ForCRL: !Ref 'UseS3ForCRL'
+        VPCCIDR: !Ref 'VPCCIDR'
+        VPCID: !GetAtt 'VPCStack.Outputs.VPCID'
   RDGWStack:
-    DependsOn: ADStack
     Condition: IncludeRDGW
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL:
-        Fn::Sub:
-          - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-microsoft-rdgateway/templates/rdgw-domain.template'
-          - S3Region: !If
-              - UsingDefaultBucket
-              - !Ref AWS::Region
-              - !Ref QSS3BucketRegion
-            S3Bucket: !If
-              - UsingDefaultBucket
-              - !Sub '${QSS3BucketName}-${AWS::Region}'
-              - !Ref QSS3BucketName
+      TemplateURL: !Sub
+        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-microsoft-rdgateway/templates/rdgw-domain.template'
+        - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+          S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
         DomainAdminPassword: !Ref 'DomainAdminPassword'
         DomainAdminUser: !Ref 'DomainAdminUser'
@@ -590,6 +550,6 @@ Resources:
         QSS3BucketName: !Ref 'QSS3BucketName'
         QSS3BucketRegion: !Ref 'QSS3BucketRegion'
         QSS3KeyPrefix: !Sub '${QSS3KeyPrefix}submodules/quickstart-microsoft-rdgateway/'
-        RDGWInstanceType: !Ref 'RDGWInstanceType'
         RDGWCIDR: !Ref 'RDGWCIDR'
+        RDGWInstanceType: !Ref 'RDGWInstanceType'
         VPCID: !GetAtt 'VPCStack.Outputs.VPCID'

--- a/templates/ad-master-2.template
+++ b/templates/ad-master-2.template
@@ -1,17 +1,14 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >-
-  This template creates a VPC infrastructure for a multi-AZ, multi-tier deployment
-  of a Windows based Application infrastructure. It installs 2 Windows Server instances
-  into private subnets in separate Availability Zones inside a VPC, as well as Remote
-  Desktop Gateway instances and managed NAT gateways into the public subnet for each
-  Availability Zone. After extending your on-premises network to the VPC, you can
-  promote the Windows Server instances to Domain Controllers in your AD forest. **WARNING**
-  This template creates Amazon EC2 Windows instance and related resources. You will
-  be billed for the AWS resources used if you create a stack from this template.
+  This template creates a VPC infrastructure for a multi-AZ, multi-tier deployment of a Windows based Application infrastructure. It installs 2
+  Windows Server instances into private subnets in separate Availability Zones inside a VPC, as well as Remote Desktop Gateway instances and managed
+  NAT gateways into the public subnet for each Availability Zone. After extending your on-premises network to the VPC, you can promote the Windows
+  Server instances to Domain Controllers in your AD forest. **WARNING** This template creates Amazon EC2 Windows instance and related resources. You
+  will be billed for the AWS resources used if you create a stack from this template.
 Metadata:
   QuickStartDocumentation:
-    EntrypointName: "Launch Active Directory on EC2 into a new VPC"
-    Order: "3"
+    EntrypointName: 'Launch Active Directory on EC2 into a new VPC'
+    Order: '3'
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
@@ -58,12 +55,38 @@ Metadata:
           - QSS3BucketRegion
           - QSS3KeyPrefix
     ParameterLabels:
-      NumberOfAZs:
-        default: Number of Availability Zones
+      ADServer1NetBIOSName:
+        default: Domain Controller 1 NetBIOS Name
+      ADServer1PrivateIP:
+        default: Domain Controller 1 Private IP Address
+      ADServer2NetBIOSName:
+        default: Domain Controller 2 NetBIOS Name
+      ADServer2PrivateIP:
+        default: Domain Controller 2 Private IP Address
+      ADServerInstanceType:
+        default: Domain Controllers Instance Type
+      AdminPassword:
+        default: Local Administrator Password
+      AdminUser:
+        default: Local Administrator User Name
       AvailabilityZones:
         default: Availability Zones
-      VPCCIDR:
-        default: VPC CIDR
+      DataDriveSizeGiB:
+        default: SYSVOL and NTDS and Data Drive Size
+      DomainDNSName:
+        default: Domain DNS Name
+      DomainNetBIOSName:
+        default: Domain NetBIOS Name
+      ExistingDomainController1IP:
+        default: IP the Instance will be used for DNS (Must be accessible)
+      ExistingDomainController2IP:
+        default: IP the Instance will be used for DNS (Must be accessible)
+      KeyPairName:
+        default: Key Pair Name
+      NumberOfAZs:
+        default: Number of Availability Zones
+      NumberOfRDGWHosts:
+        default: Number of RDGW Hosts
       PrivateSubnet1CIDR:
         default: Private Subnet 1 CIDR
       PrivateSubnet2CIDR:
@@ -76,48 +99,110 @@ Metadata:
         default: Public Subnet 2 CIDR
       PublicSubnet3CIDR:
         default: (Optional) Public Subnet 3 CIDR
-      ADServerInstanceType:
-        default: Domain Controllers Instance Type
-      ADServer1NetBIOSName:
-        default: Domain Controller 1 NetBIOS Name
-      ADServer1PrivateIP:
-        default: Domain Controller 1 Private IP Address
-      ADServer2NetBIOSName:
-        default: Domain Controller 2 NetBIOS Name
-      ADServer2PrivateIP:
-        default: Domain Controller 2 Private IP Address
-      DataDriveSizeGiB:
-        default: SYSVOL and NTDS and Data Drive Size
-      KeyPairName:
-        default: Key Pair Name
-      ExistingDomainController1IP:
-        default: IP the Instance will be used for DNS (Must be accessible)
-      ExistingDomainController2IP:
-        default: IP the Instance will be used for DNS (Must be accessible)
-      DomainDNSName:
-        default: Domain DNS Name
-      DomainNetBIOSName:
-        default: Domain NetBIOS Name
-      AdminUser:
-        default: Local Administrator User Name
-      AdminPassword:
-        default: Local Administrator Password
-      NumberOfRDGWHosts:
-        default: Number of RDGW Hosts
-      RDGWInstanceType:
-        default: Remote Desktop Gateway Instance Type
-      RDGWCIDR:
-        default: Allowed Remote Desktop Gateway External Access CIDR
       QSS3BucketName:
         default: Quick Start S3 Bucket Name
       QSS3BucketRegion:
         default: Quick Start S3 Bucket Region
       QSS3KeyPrefix:
         default: Quick Start S3 Key Prefix
+      RDGWCIDR:
+        default: Allowed Remote Desktop Gateway External Access CIDR
+      RDGWInstanceType:
+        default: Remote Desktop Gateway Instance Type
+      VPCCIDR:
+        default: VPC CIDR
 Parameters:
+  ADServer1NetBIOSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+'
+    Default: DC3
+    Description: NetBIOS name of the first additional Active Directory Domain Controller (up to 15 characters)
+    MaxLength: '15'
+    MinLength: '1'
+    Type: String
+  ADServer1PrivateIP:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
+    Default: 10.0.0.11
+    Description: Fixed private IP for the first additional Active Directory Domain Controller located in subnet 1
+    Type: String
+  ADServer2NetBIOSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+'
+    Default: DC4
+    Description: NetBIOS name of the second additional Active Directory Domain Controller (up to 15 characters)
+    MaxLength: '15'
+    MinLength: '1'
+    Type: String
+  ADServer2PrivateIP:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
+    Default: 10.0.32.11
+    Description: Fixed private IP for the second additional Active Directory Domain Controller located in subnet 2
+    Type: String
+  ADServerInstanceType:
+    AllowedValues:
+      - t2.medium
+      - t3.medium
+      - t2.large
+      - t3.large
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - m5.large
+      - m5.xlarge
+      - m5.2xlarge
+      - m5.4xlarge
+    Default: m5.large
+    Description: Amazon EC2 instance type for Active Directory Controller instances
+    Type: String
+  AdminPassword:
+    AllowedPattern: (?=^.{6,255}$)((?=.*\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*
+    Description: Password for for the new local administrator account containing letters, numbers and symbols
+    MaxLength: '32'
+    MinLength: '8'
+    NoEcho: 'true'
+    Type: String
+  AdminUser:
+    AllowedPattern: '[a-zA-Z0-9]*'
+    Default: StackAdmin
+    Description: User name for the new local administrator account This is separate from the default "Administrator" account
+    MaxLength: '25'
+    MinLength: '5'
+    Type: String
   AvailabilityZones:
-    Description: 'List of Availability Zones to use for the subnets in the VPC. Note: The logical order is preserved and only 2 AZs are used for this deployment'
+    Description:
+      'List of Availability Zones to use for the subnets in the VPC. Note: The logical order is preserved and only 2 AZs are used for this deployment'
     Type: List<AWS::EC2::AvailabilityZone::Name>
+  DataDriveSizeGiB:
+    Default: '10'
+    Description: Size of SYSVOL and NTDS data drive in GiB
+    Type: Number
+  DomainDNSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+\..+'
+    Default: example.com
+    Description: Fully qualified domain name (FQDN) of the domain you would like to join and promote to e.g. example.com example.com
+    MaxLength: '255'
+    MinLength: '2'
+    Type: String
+  DomainNetBIOSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+'
+    Default: example
+    Description:
+      NetBIOS name of the domain (up to 15 characters) you would like to join and promote to for users of earlier versions of Windows e.g. EXAMPLE
+    MaxLength: '15'
+    MinLength: '1'
+    Type: String
+  ExistingDomainController1IP:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
+    Default: 10.0.0.10
+    Description: IP of DNS server that can resolve domain (Must be accessible)
+    Type: String
+  ExistingDomainController2IP:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
+    Default: 10.0.32.10
+    Description: IP of DNS server that can resolve domain (Must be accessible)
+    Type: String
+  KeyPairName:
+    Description: Public/private key pairs allow you to securely connect to your instance after it launches
+    Type: AWS::EC2::KeyPair::KeyName
   NumberOfAZs:
     AllowedValues:
       - '2'
@@ -125,11 +210,15 @@ Parameters:
     Default: '2'
     Description: Number of Availability Zones to use in the VPC. This must match your selections in the list of Availability Zones parameter
     Type: String
-  VPCCIDR:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
-    Default: 10.0.0.0/16
-    Description: CIDR Block for the VPC
+  NumberOfRDGWHosts:
+    AllowedValues:
+      - '0'
+      - '1'
+      - '2'
+      - '3'
+      - '4'
+    Default: '1'
+    Description: Enter the number of Remote Desktop Gateway hosts to create
     Type: String
   PrivateSubnet1CIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
@@ -163,107 +252,33 @@ Parameters:
     Default: ''
     Description: CIDR Block for the public subnet 3 located in Availability Zone 3
     Type: String
-  ADServerInstanceType:
-    AllowedValues:
-      - t2.medium
-      - t3.medium
-      - t2.large
-      - t3.large
-      - m4.large
-      - m4.xlarge
-      - m4.2xlarge
-      - m4.4xlarge
-      - m5.large
-      - m5.xlarge
-      - m5.2xlarge
-      - m5.4xlarge
-    Default: m5.large
-    Description: Amazon EC2 instance type for Active Directory Controller instances
+  QSS3BucketName:
+    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
+    ConstraintDescription:
+      Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
+    Default: aws-quickstart
+    Description:
+      S3 bucket name for CA CRL storage. Bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or
+      end with a hyphen (-)
     Type: String
-  ADServer1NetBIOSName:
-    AllowedPattern: '[a-zA-Z0-9\-]+'
-    Default: DC3
-    Description: NetBIOS name of the first additional Active Directory Domain Controller (up to 15 characters)
-    MaxLength: '15'
-    MinLength: '1'
+  QSS3BucketRegion:
+    Default: us-east-1
+    Description: The AWS Region where the Quick Start S3 bucket (QSS3BucketName) is hosted. When using your own bucket, you must specify this value
     Type: String
-  ADServer1PrivateIP:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
-    Default: 10.0.0.11
-    Description: Fixed private IP for the first additional Active Directory Domain Controller located in subnet 1
+  QSS3KeyPrefix:
+    AllowedPattern: ^[0-9a-zA-Z-/]*$
+    ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)
+    Default: quickstart-microsoft-activedirectory/
+    Description:
+      S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and
+      forward slash (/)
     Type: String
-  ADServer2NetBIOSName:
-    AllowedPattern: '[a-zA-Z0-9\-]+'
-    Default: DC4
-    Description: NetBIOS name of the second additional Active Directory Domain Controller (up to 15 characters)
-    MaxLength: '15'
-    MinLength: '1'
-    Type: String
-  ADServer2PrivateIP:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
-    Default: 10.0.32.11
-    Description: Fixed private IP for the second additional Active Directory Domain Controller located in subnet 2
-    Type: String
-  DataDriveSizeGiB:
-    Type: 'Number'
-    Default: '10'
-    Description: Size of SYSVOL and NTDS data drive in GiB
-  KeyPairName:
-    Description: Public/private key pairs allow you to securely connect to your instance after it launches
-    Type: AWS::EC2::KeyPair::KeyName
-  ExistingDomainController1IP:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
-    Default: 10.0.0.10
-    Description: IP of DNS server that can resolve domain (Must be accessible)
-    Type: String
-  ExistingDomainController2IP:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
-    Default: 10.0.32.10
-    Description: IP of DNS server that can resolve domain (Must be accessible)
-    Type: String
-  DomainDNSName:
-    AllowedPattern: '[a-zA-Z0-9\-]+\..+'
-    Default: example.com
-    Description: Fully qualified domain name (FQDN) of the domain you would like to join and promote to e.g. example.com
-      example.com
-    MaxLength: '255'
-    MinLength: '2'
-    Type: String
-  DomainNetBIOSName:
-    AllowedPattern: '[a-zA-Z0-9\-]+'
-    Default: example
-    Description: NetBIOS name of the domain (up to 15 characters) you would like to join and promote to for users of earlier versions of Windows e.g. EXAMPLE
-    MaxLength: '15'
-    MinLength: '1'
-    Type: String
-  AdminUser:
-    AllowedPattern: '[a-zA-Z0-9]*'
-    Default: StackAdmin
-    Description: User name for the new local administrator account This is separate from the default "Administrator" account
-    MaxLength: '25'
-    MinLength: '5'
-    Type: String
-  AdminPassword:
-    AllowedPattern: (?=^.{6,255}$)((?=.*\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*
-    Description: Password for for the new local administrator account containing letters, numbers and symbols
-    MaxLength: '32'
-    MinLength: '8'
-    NoEcho: 'true'
-    Type: String
-  NumberOfRDGWHosts:
-    AllowedValues:
-      - '0'
-      - '1'
-      - '2'
-      - '3'
-      - '4'
-    Default: '1'
-    Description: Enter the number of Remote Desktop Gateway hosts to create
+  RDGWCIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
+    Description: Allowed CIDR Block for external access to the Remote Desktop Gateways
     Type: String
   RDGWInstanceType:
-    Description: Amazon EC2 instance type for the Remote Desktop Gateway instances
-    Type: String
-    Default: t3.large
     AllowedValues:
       - t2.small
       - t2.medium
@@ -275,131 +290,74 @@ Parameters:
       - m5.xlarge
       - m5.2xlarge
       - m5.4xlarge
-  RDGWCIDR:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
-    Description: Allowed CIDR Block for external access to the Remote Desktop Gateways
+    Default: t3.large
+    Description: Amazon EC2 instance type for the Remote Desktop Gateway instances
     Type: String
-  QSS3BucketName:
-    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
-    ConstraintDescription: Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen
-      (-).
-    Default: aws-quickstart
-    Description: S3 bucket name for CA CRL storage. Bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)
-    Type: String
-  QSS3BucketRegion:
-    Default: us-east-1
-    Description: The AWS Region where the Quick Start S3 bucket (QSS3BucketName) is hosted. When using your own bucket, you must specify this value
-    Type: String
-  QSS3KeyPrefix:
-    AllowedPattern: ^[0-9a-zA-Z-/]*$
-    ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)
-    Default: quickstart-microsoft-activedirectory/
-    Description: S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)
+  VPCCIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.0.0/16
+    Description: CIDR Block for the VPC
     Type: String
 Conditions:
-  IsTwoAz: !Equals
-    - !Ref 'NumberOfAZs'
-    - '2'
+  IncludeRDGW: !Not [!Equals [!Ref NumberOfRDGWHosts, '0']]
+  IsTwoAz: !Equals [!Ref 'NumberOfAZs', '2']
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
-  IncludeRDGW: !Not
-    - !Equals
-      - !Ref NumberOfRDGWHosts
-      - '0'
 Resources:
   VPCStack:
-      Type: AWS::CloudFormation::Stack
-      Properties:
-        TemplateURL:
-          Fn::Sub:
-            - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template'
-            - S3Region: !If
-                - UsingDefaultBucket
-                - !Ref AWS::Region
-                - !Ref QSS3BucketRegion
-              S3Bucket: !If
-                - UsingDefaultBucket
-                - !Sub '${QSS3BucketName}-${AWS::Region}'
-                - !Ref QSS3BucketName
-        Parameters:
-          AvailabilityZones: !Join
-            - ','
-            - !Ref 'AvailabilityZones'
-          KeyPairName: !Ref 'KeyPairName'
-          NumberOfAZs: !If
-            - IsTwoAz
-            - '2'
-            - '3'
-          PrivateSubnet1ACIDR: !Ref 'PrivateSubnet1CIDR'
-          PrivateSubnet2ACIDR: !Ref 'PrivateSubnet2CIDR'
-          PrivateSubnet3ACIDR: !If
-            - IsTwoAz
-            - !Ref 'AWS::NoValue'
-            - !Ref 'PrivateSubnet3CIDR'
-          PublicSubnet1CIDR: !Ref 'PublicSubnet1CIDR'
-          PublicSubnet2CIDR: !Ref 'PublicSubnet2CIDR'
-          PublicSubnet3CIDR: !If
-            - IsTwoAz
-            - !Ref 'AWS::NoValue'
-            - !Ref 'PublicSubnet3CIDR'
-          VPCCIDR: !Ref 'VPCCIDR'
-  PlaceHolderSG: 
-    Type: AWS::EC2::SecurityGroup
-    Properties: 
-      GroupDescription: Place Holder Security Group.
-      VpcId: !GetAtt 'VPCStack.Outputs.VPCID'
-  ADStack:
-    DependsOn: VPCStack
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL:
-        Fn::Sub:
-          - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/ad-2.template'
-          - S3Region: !If
-              - UsingDefaultBucket
-              - !Ref AWS::Region
-              - !Ref QSS3BucketRegion
-            S3Bucket: !If
-              - UsingDefaultBucket
-              - !Sub '${QSS3BucketName}-${AWS::Region}'
-              - !Ref QSS3BucketName
+      TemplateURL: !Sub
+        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template'
+        - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+          S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
+        AvailabilityZones: !Join [',', !Ref 'AvailabilityZones']
+        KeyPairName: !Ref 'KeyPairName'
+        NumberOfAZs: !If [IsTwoAz, '2', '3']
+        PrivateSubnet1ACIDR: !Ref 'PrivateSubnet1CIDR'
+        PrivateSubnet2ACIDR: !Ref 'PrivateSubnet2CIDR'
+        PrivateSubnet3ACIDR: !If [IsTwoAz, !Ref 'AWS::NoValue', !Ref 'PrivateSubnet3CIDR']
+        PublicSubnet1CIDR: !Ref 'PublicSubnet1CIDR'
+        PublicSubnet2CIDR: !Ref 'PublicSubnet2CIDR'
+        PublicSubnet3CIDR: !If [IsTwoAz, !Ref 'AWS::NoValue', !Ref 'PublicSubnet3CIDR']
         VPCCIDR: !Ref 'VPCCIDR'
-        VPCID: !GetAtt 'VPCStack.Outputs.VPCID'
-        Subnet1ID: !GetAtt 'VPCStack.Outputs.PrivateSubnet1AID'
-        Subnet2ID: !GetAtt 'VPCStack.Outputs.PrivateSubnet2AID'
-        DomainControllersSG: !Ref 'PlaceHolderSG'
-        ADServerInstanceType: !Ref 'ADServerInstanceType'
+  ADStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub
+        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/ad-2.template'
+        - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+          S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+      Parameters:
         ADServer1NetBIOSName: !Ref 'ADServer1NetBIOSName'
         ADServer1PrivateIP: !Ref 'ADServer1PrivateIP'
         ADServer2NetBIOSName: !Ref 'ADServer2NetBIOSName'
         ADServer2PrivateIP: !Ref 'ADServer2PrivateIP'
+        ADServerInstanceType: !Ref 'ADServerInstanceType'
         DataDriveSizeGiB: !Ref 'DataDriveSizeGiB'
-        KeyPairName: !Ref 'KeyPairName'
-        JoinAndPromote: 'No'
-        ExistingDomainController1IP: !Ref 'ExistingDomainController1IP'
-        ExistingDomainController2IP: !Ref 'ExistingDomainController2IP'
         DomainDNSName: !Ref 'DomainDNSName'
         DomainNetBIOSName: !Ref 'DomainNetBIOSName'
+        ExistingDomainController1IP: !Ref 'ExistingDomainController1IP'
+        ExistingDomainController2IP: !Ref 'ExistingDomainController2IP'
+        JoinAndPromote: 'No'
+        KeyPairName: !Ref 'KeyPairName'
         QSS3BucketName: !Ref 'QSS3BucketName'
         QSS3BucketRegion: !Ref 'QSS3BucketRegion'
         QSS3KeyPrefix: !Ref 'QSS3KeyPrefix'
+        Subnet1ID: !GetAtt 'VPCStack.Outputs.PrivateSubnet1AID'
+        Subnet2ID: !GetAtt 'VPCStack.Outputs.PrivateSubnet2AID'
+        VPCCIDR: !Ref 'VPCCIDR'
+        VPCID: !GetAtt 'VPCStack.Outputs.VPCID'
   RDGWStack:
-    DependsOn: ADStack
     Condition: IncludeRDGW
+    DependsOn: ADStack
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL:
-        Fn::Sub:
-          - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-microsoft-rdgateway/templates/rdgw-standalone.template'
-          - S3Region: !If
-              - UsingDefaultBucket
-              - !Ref AWS::Region
-              - !Ref QSS3BucketRegion
-            S3Bucket: !If
-              - UsingDefaultBucket
-              - !Sub '${QSS3BucketName}-${AWS::Region}'
-              - !Ref QSS3BucketName
+      TemplateURL: !Sub
+        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-microsoft-rdgateway/templates/rdgw-standalone.template'
+        - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+          S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
         AdminPassword: !Ref 'AdminPassword'
         AdminUser: !Ref 'AdminUser'

--- a/templates/ad-master-3.template
+++ b/templates/ad-master-3.template
@@ -1,19 +1,15 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >-
-  This template creates a VPC infrastructure for a multi-AZ, multi-tier deployment
-  of a Windows based Application infrastructure. It deploys a managed Microsoft AD
-  Directory Service into private subnets in separate Availability Zones inside a VPC,
-  as well as Remote Desktop Gateway instances and managed NAT gateways into the public
-  subnet for each Availability Zone. The default Domain Administrator user is 'admin'.  For
-  adding members to the domain, ensure that they are launched into the domain member
-  security group created by this template and then configure them to use the AD instances
-  fixed private IP addresses as the DNS server. **WARNING** This template creates
-  Amazon EC2 Windows instance and related resources. You will be billed for the AWS
-  resources used if you create a stack from this template.
+  This template creates a VPC infrastructure for a multi-AZ, multi-tier deployment of a Windows based Application infrastructure. It deploys a managed
+  Microsoft AD Directory Service into private subnets in separate Availability Zones inside a VPC, as well as Remote Desktop Gateway instances and
+  managed NAT gateways into the public subnet for each Availability Zone. The default Domain Administrator user is 'admin'.  For adding members to the
+  domain, ensure that they are launched into the domain member security group created by this template and then configure them to use the AD instances
+  fixed private IP addresses as the DNS server. **WARNING** This template creates Amazon EC2 Windows instance and related resources. You will be
+  billed for the AWS resources used if you create a stack from this template.
 Metadata:
   QuickStartDocumentation:
-    EntrypointName: "Launch AWS Managed Active Directory into a new VPC"
-    Order: "6"
+    EntrypointName: 'Launch AWS Managed Active Directory into a new VPC'
+    Order: '6'
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
@@ -74,14 +70,50 @@ Metadata:
           - QSS3BucketRegion
           - QSS3KeyPrefix
     ParameterLabels:
-      NumberOfAZs:
-        default: Number of Availability Zones
+      ADEdition:
+        default: AWS Microsoft AD Edition
       AvailabilityZones:
         default: Availability Zones
-      VPCCIDR:
-        default: VPC CIDR
+      CaDataDriveSizeGiB:
+        default: CA Data Drive Size
+      CaHashAlgorithm:
+        default: CA Hash Algorithm
+      CaKeyLength:
+        default: CA Key Length
+      CaServerInstanceType:
+        default: CA Instance Type
+      CaValidityPeriodUnits:
+        default: Enterprise Root or Subordinate CA Certificate Validity Period in Years
       DHCPOptionSet:
-        default: Create a DHCP Options set 
+        default: Create a DHCP Options set
+      DomainAdminPassword:
+        default: Admin Account Password
+      DomainDNSName:
+        default: Domain DNS Name
+      DomainNetBIOSName:
+        default: Domain NetBIOS Name
+      EntCaServerNetBIOSName:
+        default: Enterprise Root or Subordinate CA NetBIOS Name
+      KeyPairName:
+        default: Key Pair Name
+      MgmtDataDriveSizeGiB:
+        default: Data Drive Size
+      MgmtServer:
+        default: Deploy Management Server
+      MgmtServerInstanceType:
+        default: Management Server Instance Type
+      MgmtServerNetBIOSName:
+        default: Management Server NetBIOS Name
+      NumberOfAZs:
+        default: Number of Availability Zones
+      NumberOfRDGWHosts:
+        default: Number of RDGW Hosts
+      OrCaServerNetBIOSName:
+        default: Offline Root CA NetBIOS Name (Only Used For Two Tier PKI)
+      OrCaValidityPeriodUnits:
+        default: Offline Root CA Certificate Validity Period in Years (Only Used For Two Tier PKI)
+      PKI:
+        default: Deploy PKI Infrastructure
       PrivateSubnet1CIDR:
         default: Private Subnet 1 CIDR
       PrivateSubnet2CIDR:
@@ -94,76 +126,67 @@ Metadata:
         default: Public Subnet 2 CIDR
       PublicSubnet3CIDR:
         default: (Optional) Public Subnet 3 CIDR
-      KeyPairName:
-        default: Key Pair Name
-      DomainDNSName:
-        default: Domain DNS Name
-      DomainNetBIOSName:
-        default: Domain NetBIOS Name
-      DomainAdminPassword:
-        default: Admin Account Password
-      ADEdition:
-        default: AWS Microsoft AD Edition
-      MgmtServer:
-        default: Deploy Management Server
-      MgmtServerInstanceType:
-        default: Management Server Instance Type
-      MgmtDataDriveSizeGiB:
-        default: Data Drive Size
-      MgmtServerNetBIOSName:
-        default: Management Server NetBIOS Name
-      PKI:
-        default: Deploy PKI Infrastructure
-      CaServerInstanceType:
-        default: CA Instance Type
-      CaAmi:
-        default: CA SSM Parameter Value for lastest AMI ID
-      CaDataDriveSizeGiB:
-        default: CA Data Drive Size
-      OrCaServerNetBIOSName:
-        default: Offline Root CA NetBIOS Name (Only Used For Two Tier PKI)
-      EntCaServerNetBIOSName:
-        default: Enterprise Root or Subordinate CA NetBIOS Name
-      CaKeyLength:
-        default: CA Key Length
-      CaHashAlgorithm:
-        default: CA Hash Algorithm
-      OrCaValidityPeriodUnits:
-        default: Offline Root CA Certificate Validity Period in Years (Only Used For Two Tier PKI)
-      CaValidityPeriodUnits:
-        default: Enterprise Root or Subordinate CA Certificate Validity Period in Years
-      UseS3ForCRL:
-        default: Use S3 for CA CRL Location
-      S3CRLBucketName:
-        default: CA CRL S3 Bucket Name
-      NumberOfRDGWHosts:
-        default: Number of RDGW Hosts
-      RDGWInstanceType:
-        default: Remote Desktop Gateway Instance Type
-      RDGWCIDR:
-        default: Allowed Remote Desktop Gateway External Access CIDR
       QSS3BucketName:
         default: Quick Start S3 bucket name
       QSS3BucketRegion:
         default: Quick Start S3 bucket region
       QSS3KeyPrefix:
         default: Quick Start S3 key prefix
+      RDGWCIDR:
+        default: Allowed Remote Desktop Gateway External Access CIDR
+      RDGWInstanceType:
+        default: Remote Desktop Gateway Instance Type
+      S3CRLBucketName:
+        default: CA CRL S3 Bucket Name
+      UseS3ForCRL:
+        default: Use S3 for CA CRL Location
+      VPCCIDR:
+        default: VPC CIDR
 Parameters:
-  AvailabilityZones:
-    Description: 'List of Availability Zones to use for the subnets in the VPC. Note: The logical order is preserved and only 2 AZs are used for this deployment'
-    Type: List<AWS::EC2::AvailabilityZone::Name>
-  NumberOfAZs:
+  ADEdition:
     AllowedValues:
-      - '2'
-      - '3'
-    Default: '2'
-    Description: Number of Availability Zones to use in the VPC. This must match your selections in the list of Availability Zones parameter
+      - Standard
+      - Enterprise
+    Default: Enterprise
+    Description: The AWS Microsoft AD Edition you wish to deploy
     Type: String
-  VPCCIDR:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
-    Default: 10.0.0.0/16
-    Description: CIDR Block for the VPC
+  AvailabilityZones:
+    Description:
+      'List of Availability Zones to use for the subnets in the VPC. Note: The logical order is preserved and only 2 AZs are used for this deployment'
+    Type: List<AWS::EC2::AvailabilityZone::Name>
+  CaDataDriveSizeGiB:
+    Default: '2'
+    Description: Size of the data drive in GiB for the CA instance(s)
+    Type: Number
+  CaHashAlgorithm:
+    AllowedValues:
+      - SHA256
+      - SHA384
+      - SHA512
+    Default: SHA256
+    Description: CA(s) Hash Algorithm for Siging Certificates
+    Type: String
+  CaKeyLength:
+    AllowedValues:
+      - '2048'
+      - '4096'
+    Default: '2048'
+    Description: CA(s) Cryptographic Provider Key Length
+    Type: String
+  CaServerInstanceType:
+    AllowedValues:
+      - t2.small
+      - t3.small
+      - t2.medium
+      - t3.medium
+      - t2.large
+      - t3.large
+    Default: t3.medium
+    Description: Amazon EC2 instance type for the CA instance(s)
+    Type: String
+  CaValidityPeriodUnits:
+    Default: '5'
+    Description: Validity Period in Years
     Type: String
   DHCPOptionSet:
     AllowedValues:
@@ -171,6 +194,102 @@ Parameters:
       - 'No'
     Default: 'Yes'
     Description: Do you want to create and apply a new DHCP Options Set
+    Type: String
+  DomainAdminPassword:
+    AllowedPattern: (?=^.{6,255}$)((?=.*\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*
+    Description: Password for the Admin user account. Must be at least 8 characters containing letters, numbers and symbols
+    MaxLength: '32'
+    MinLength: '8'
+    NoEcho: 'true'
+    Type: String
+  DomainDNSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+\..+'
+    Default: example.com
+    Description: Fully qualified domain name (FQDN) of the forest root domain e.g. example.com
+    MaxLength: '255'
+    MinLength: '2'
+    Type: String
+  DomainNetBIOSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+'
+    Default: example
+    Description: NetBIOS name of the domain (upto 15 characters) for users of earlier versions of Windows e.g. EXAMPLE
+    MaxLength: '15'
+    MinLength: '1'
+    Type: String
+  EntCaServerNetBIOSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+'
+    Default: ENTCA1
+    Description: NetBIOS name of the Enterprise Root or Subordinate CA server (up to 15 characters)
+    MaxLength: '15'
+    MinLength: '1'
+    Type: String
+  KeyPairName:
+    Description: Public/private key pairs allow you to securely connect to your instance after it launches
+    Type: AWS::EC2::KeyPair::KeyName
+  MgmtDataDriveSizeGiB:
+    Default: '2'
+    Description: Size of the Managment Server Data Drive in GiB
+    Type: Number
+  MgmtServer:
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Default: 'true'
+    Description: Do you want to deploy a Management Server
+    Type: String
+  MgmtServerInstanceType:
+    AllowedValues:
+      - t2.small
+      - t3.small
+      - t2.medium
+      - t3.medium
+      - t2.large
+      - t3.large
+    Default: t3.medium
+    Description: Amazon EC2 instance type for the Management Server
+    Type: String
+  MgmtServerNetBIOSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+'
+    Default: MGMT1
+    Description: NetBIOS name of the Management Server server (up to 15 characters)
+    MaxLength: '15'
+    MinLength: '1'
+    Type: String
+  NumberOfAZs:
+    AllowedValues:
+      - '2'
+      - '3'
+    Default: '2'
+    Description: Number of Availability Zones to use in the VPC. This must match your selections in the list of Availability Zones parameter
+    Type: String
+  NumberOfRDGWHosts:
+    AllowedValues:
+      - '0'
+      - '1'
+      - '2'
+      - '3'
+      - '4'
+    Default: '1'
+    Description: Enter the number of Remote Desktop Gateway instances to create
+    Type: String
+  OrCaServerNetBIOSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+'
+    Default: ORCA1
+    Description: NetBIOS name of the Offline Root CA server (Only Used For Two Tier PKI) (up to 15 characters)
+    MaxLength: '15'
+    MinLength: '1'
+    Type: String
+  OrCaValidityPeriodUnits:
+    Default: '10'
+    Description: Validity Period in Years (Only Used For Two Tier PKI)
+    Type: String
+  PKI:
+    AllowedValues:
+      - One-Tier
+      - Two-Tier
+      - 'No'
+    Default: 'No'
+    Description: Deploy Two Tier (Offline Root with Subordinate Enterprise CA) or One Tier (Enterprise Root CA) PKI Infrastructure
     Type: String
   PrivateSubnet1CIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
@@ -204,147 +323,31 @@ Parameters:
     Default: ''
     Description: CIDR Block for the public subnet 3 located in Availability Zone 3
     Type: String
-  KeyPairName:
-    Description: Public/private key pairs allow you to securely connect to your instance after it launches
-    Type: AWS::EC2::KeyPair::KeyName
-  DomainDNSName:
-    AllowedPattern: '[a-zA-Z0-9\-]+\..+'
-    Description: Fully qualified domain name (FQDN) of the forest root domain e.g. example.com
-    Type: String
-    Default: example.com
-    MinLength: '2'
-    MaxLength: '255'
-  DomainNetBIOSName:
-    AllowedPattern: '[a-zA-Z0-9\-]+'
-    Description: NetBIOS name of the domain (upto 15 characters) for users of earlier versions of Windows e.g. EXAMPLE
-    Type: String
-    Default: example
-    MinLength: '1'
-    MaxLength: '15'
-  DomainAdminPassword:
-    AllowedPattern: (?=^.{6,255}$)((?=.*\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*
-    Description: Password for the Admin user account. Must be at least 8 characters containing letters, numbers and symbols
-    NoEcho: 'true'
-    MinLength: '8'
-    MaxLength: '32'
-    Type: String
-  ADEdition:
-    AllowedValues:
-      - Standard
-      - Enterprise
-    Default: Enterprise
-    Description: The AWS Microsoft AD Edition you wish to deploy
-    Type: String
-  MgmtServer:
-    AllowedValues:
-      - 'true'
-      - 'false'
-    Default: 'true'
-    Description: Do you want to deploy a Management Server
-    Type: String
-  MgmtServerInstanceType:
-    AllowedValues:
-      - t2.small
-      - t3.small
-      - t2.medium
-      - t3.medium
-      - t2.large
-      - t3.large
-    Default: t3.medium
-    Description: Amazon EC2 instance type for the Management Server
-    Type: String
-  MgmtDataDriveSizeGiB:
-    Default: '2'
-    Description: Size of the Managment Server Data Drive in GiB
-    Type: 'Number'
-  MgmtServerNetBIOSName:
-    AllowedPattern: '[a-zA-Z0-9\-]+'
-    Default: MGMT1
-    Description: NetBIOS name of the Management Server server (up to 15 characters)
-    MaxLength: '15'
-    MinLength: '1'
-    Type: String
-  PKI:
-    AllowedValues:
-      - 'One-Tier'
-      - 'Two-Tier'
-      - 'No'
-    Default: 'No'
-    Description: Deploy Two Tier (Offline Root with Subordinate Enterprise CA) or One Tier (Enterprise Root CA) PKI Infrastructure
-    Type: String
-  CaServerInstanceType:
-    AllowedValues:
-      - t2.small
-      - t3.small
-      - t2.medium
-      - t3.medium
-      - t2.large
-      - t3.large
-    Default: t3.medium
-    Description: Amazon EC2 instance type for the CA instance(s)
-    Type: String
-  CaDataDriveSizeGiB:
-    Type: 'Number'
-    Default: '2'
-    Description: Size of the data drive in GiB for the CA instance(s)
-  OrCaServerNetBIOSName:
-    AllowedPattern: '[a-zA-Z0-9\-]+'
-    Default: ORCA1
-    Description: NetBIOS name of the Offline Root CA server (Only Used For Two Tier PKI) (up to 15 characters)
-    MaxLength: '15'
-    MinLength: '1'
-    Type: String
-  EntCaServerNetBIOSName:
-    AllowedPattern: '[a-zA-Z0-9\-]+'
-    Default: ENTCA1
-    Description: NetBIOS name of the Enterprise Root or Subordinate CA server (up to 15 characters)
-    MaxLength: '15'
-    MinLength: '1'
-    Type: String
-  CaKeyLength:
-    Description: CA(s) Cryptographic Provider Key Length
-    AllowedValues:
-      - '2048'
-      - '4096'
-    Default: '2048'
-    Type: String
-  CaHashAlgorithm:
-    Description: CA(s) Hash Algorithm for Siging Certificates
-    AllowedValues:
-      - 'SHA256'
-      - 'SHA384'
-      - 'SHA512'
-    Default: 'SHA256'
-    Type: String
-  OrCaValidityPeriodUnits:
-    Description: Validity Period in Years (Only Used For Two Tier PKI)
-    Default: '10'
-    Type: String
-  CaValidityPeriodUnits:
-    Description: Validity Period in Years
-    Default: '5'
-    Type: String
-  UseS3ForCRL:
-    Description: Store CA CRL(s) in an S3 bucket    
-    AllowedValues:
-      - 'Yes'
-      - 'No'
-    Default: 'No'
-    Type: String
-  S3CRLBucketName:
+  QSS3BucketName:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
-    Default: examplebucket
-    Description: S3 bucket name for CA CRL(s) storage. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)
+    ConstraintDescription:
+      Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)
+    Default: aws-quickstart
+    Description:
+      S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-).
+      It cannot start or end with a hyphen (-)
     Type: String
-  NumberOfRDGWHosts:
-    AllowedValues:
-      - '0'
-      - '1'
-      - '2'
-      - '3'
-      - '4'
-    Default: '1'
-    Description: Enter the number of Remote Desktop Gateway instances to create
+  QSS3BucketRegion:
+    Default: us-east-1
+    Description: The AWS Region where the Quick Start S3 bucket (QSS3BucketName) is hosted. When using your own bucket, you must specify this value
+    Type: String
+  QSS3KeyPrefix:
+    AllowedPattern: ^[0-9a-zA-Z-/]*$
+    ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)
+    Default: quickstart-microsoft-activedirectory/
+    Description:
+      S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and
+      forward slash (/)
+    Type: String
+  RDGWCIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
+    Description: Allowed CIDR Block for external access to the Remote Desktop Gateways
     Type: String
   RDGWInstanceType:
     AllowedValues:
@@ -358,149 +361,104 @@ Parameters:
       - m5.xlarge
       - m5.2xlarge
       - m5.4xlarge
-    Description: Amazon EC2 instance type for the Remote Desktop Gateway instances
     Default: t3.large
+    Description: Amazon EC2 instance type for the Remote Desktop Gateway instances
     Type: String
-  RDGWCIDR:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
-    Description: Allowed CIDR Block for external access to the Remote Desktop Gateways
-    Type: String
-  QSS3BucketName:
+  S3CRLBucketName:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
-    ConstraintDescription: Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)
-    Default: aws-quickstart
-    Description: S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)
+    Default: examplebucket
+    Description:
+      S3 bucket name for CA CRL(s) storage. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It
+      cannot start or end with a hyphen (-)
     Type: String
-  QSS3BucketRegion:
-    Default: us-east-1
-    Description: The AWS Region where the Quick Start S3 bucket (QSS3BucketName) is hosted. When using your own bucket, you must specify this value
+  UseS3ForCRL:
+    AllowedValues:
+      - 'Yes'
+      - 'No'
+    Default: 'No'
+    Description: Store CA CRL(s) in an S3 bucket
     Type: String
-  QSS3KeyPrefix:
-    AllowedPattern: ^[0-9a-zA-Z-/]*$
-    ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)
-    Default: quickstart-microsoft-activedirectory/
-    Description: S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)
+  VPCCIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.0.0/16
+    Description: CIDR Block for the VPC
     Type: String
 Conditions:
-  IsTwoAz: !Equals
-    - !Ref 'NumberOfAZs'
-    - '2'
+  IncludeRDGW: !Not [!Equals [!Ref NumberOfRDGWHosts, '0']]
+  IsTwoAz: !Equals [!Ref 'NumberOfAZs', '2']
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
-  IncludeRDGW: !Not
-    - !Equals
-      - !Ref NumberOfRDGWHosts
-      - '0'
 Rules:
   S3CRLBucketNameValidation:
     RuleCondition: !And
-      - !Equals
-        - !Ref UseS3ForCRL
-        - 'Yes'
-      - !Not 
-        - !Equals
-          - !Ref PKI
-          - 'No'
+      - !Equals [!Ref UseS3ForCRL, 'Yes']
+      - !Not [!Equals [!Ref PKI, 'No']]
     Assertions:
       - AssertDescription: CRL BucketName cannot must be valid BucketName
         Assert: !Not [!Equals [!Ref S3CRLBucketName, 'examplebucket']]
 Resources:
   VPCStack:
-      Type: AWS::CloudFormation::Stack
-      Properties:
-        TemplateURL:
-          Fn::Sub:
-            - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template'
-            - S3Region: !If
-                - UsingDefaultBucket
-                - !Ref AWS::Region
-                - !Ref QSS3BucketRegion
-              S3Bucket: !If
-                - UsingDefaultBucket
-                - !Sub '${QSS3BucketName}-${AWS::Region}'
-                - !Ref QSS3BucketName
-        Parameters:
-          AvailabilityZones: !Join
-            - ','
-            - !Ref 'AvailabilityZones'
-          KeyPairName: !Ref 'KeyPairName'
-          NumberOfAZs: !If
-            - IsTwoAz
-            - '2'
-            - '3'
-          PrivateSubnet1ACIDR: !Ref 'PrivateSubnet1CIDR'
-          PrivateSubnet2ACIDR: !Ref 'PrivateSubnet2CIDR'
-          PrivateSubnet3ACIDR: !If
-            - IsTwoAz
-            - !Ref 'AWS::NoValue'
-            - !Ref 'PrivateSubnet3CIDR'
-          PublicSubnet1CIDR: !Ref 'PublicSubnet1CIDR'
-          PublicSubnet2CIDR: !Ref 'PublicSubnet2CIDR'
-          PublicSubnet3CIDR: !If
-            - IsTwoAz
-            - !Ref 'AWS::NoValue'
-            - !Ref 'PublicSubnet3CIDR'
-          VPCCIDR: !Ref 'VPCCIDR'
-  ADStack:
-    DependsOn: VPCStack
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL:
-        Fn::Sub:
-          - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/ad-3.template'
-          - S3Region: !If
-              - UsingDefaultBucket
-              - !Ref AWS::Region
-              - !Ref QSS3BucketRegion
-            S3Bucket: !If
-              - UsingDefaultBucket
-              - !Sub '${QSS3BucketName}-${AWS::Region}'
-              - !Ref QSS3BucketName
+      TemplateURL: !Sub
+        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template'
+        - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+          S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
+        AvailabilityZones: !Join [',', !Ref 'AvailabilityZones']
+        KeyPairName: !Ref 'KeyPairName'
+        NumberOfAZs: !If [IsTwoAz, '2', '3']
+        PrivateSubnet1ACIDR: !Ref 'PrivateSubnet1CIDR'
+        PrivateSubnet2ACIDR: !Ref 'PrivateSubnet2CIDR'
+        PrivateSubnet3ACIDR: !If [IsTwoAz, !Ref 'AWS::NoValue', !Ref 'PrivateSubnet3CIDR']
+        PublicSubnet1CIDR: !Ref 'PublicSubnet1CIDR'
+        PublicSubnet2CIDR: !Ref 'PublicSubnet2CIDR'
+        PublicSubnet3CIDR: !If [IsTwoAz, !Ref 'AWS::NoValue', !Ref 'PublicSubnet3CIDR']
+        VPCCIDR: !Ref 'VPCCIDR'
+  ADStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub
+        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/ad-3.template'
+        - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+          S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+      Parameters:
+        ADEdition: !Ref 'ADEdition'
+        CaDataDriveSizeGiB: !Ref 'CaDataDriveSizeGiB'
+        CaHashAlgorithm: !Ref 'CaHashAlgorithm'
+        CaKeyLength: !Ref 'CaKeyLength'
+        CaServerInstanceType: !Ref 'CaServerInstanceType'
+        CaValidityPeriodUnits: !Ref 'CaValidityPeriodUnits'
+        DHCPOptionSet: !Ref 'DHCPOptionSet'
         DomainAdminPassword: !Ref 'DomainAdminPassword'
         DomainDNSName: !Ref 'DomainDNSName'
         DomainNetBIOSName: !Ref 'DomainNetBIOSName'
-        ADEdition: !Ref 'ADEdition'
+        EntCaServerNetBIOSName: !Ref 'EntCaServerNetBIOSName'
+        KeyPairName: !Ref 'KeyPairName'
+        MgmtDataDriveSizeGiB: !Ref 'MgmtDataDriveSizeGiB'
+        MgmtServer: !Ref 'MgmtServer'
+        MgmtServerInstanceType: !Ref 'MgmtServerInstanceType'
+        MgmtServerNetBIOSName: !Ref 'MgmtServerNetBIOSName'
+        OrCaServerNetBIOSName: !Ref 'OrCaServerNetBIOSName'
+        OrCaValidityPeriodUnits: !Ref 'OrCaValidityPeriodUnits'
+        PKI: !Ref 'PKI'
         PrivateSubnet1ID: !GetAtt 'VPCStack.Outputs.PrivateSubnet1AID'
         PrivateSubnet2ID: !GetAtt 'VPCStack.Outputs.PrivateSubnet2AID'
         QSS3BucketName: !Ref 'QSS3BucketName'
         QSS3BucketRegion: !Ref 'QSS3BucketRegion'
         QSS3KeyPrefix: !Ref 'QSS3KeyPrefix'
+        S3CRLBucketName: !Ref 'S3CRLBucketName'
+        UseS3ForCRL: !Ref 'UseS3ForCRL'
         VPCCIDR: !Ref 'VPCCIDR'
         VPCID: !GetAtt 'VPCStack.Outputs.VPCID'
-        DHCPOptionSet: !Ref 'DHCPOptionSet'
-        MgmtServer: !Ref 'MgmtServer'
-        MgmtServerInstanceType: !Ref 'MgmtServerInstanceType'
-        MgmtDataDriveSizeGiB: !Ref 'MgmtDataDriveSizeGiB'
-        KeyPairName: !Ref 'KeyPairName'
-        MgmtServerNetBIOSName: !Ref 'MgmtServerNetBIOSName'
-        PKI: !Ref 'PKI'
-        CaServerInstanceType: !Ref 'CaServerInstanceType'
-        CaDataDriveSizeGiB: !Ref 'CaDataDriveSizeGiB'
-        OrCaServerNetBIOSName: !Ref 'OrCaServerNetBIOSName'
-        EntCaServerNetBIOSName: !Ref 'EntCaServerNetBIOSName'
-        CaKeyLength: !Ref 'CaKeyLength'
-        CaHashAlgorithm: !Ref 'CaHashAlgorithm'
-        OrCaValidityPeriodUnits: !Ref 'OrCaValidityPeriodUnits'
-        CaValidityPeriodUnits: !Ref 'CaValidityPeriodUnits'
-        UseS3ForCRL: !Ref 'UseS3ForCRL'
-        S3CRLBucketName: !Ref 'S3CRLBucketName'
   RDGWStack:
-    DependsOn: ADStack
     Condition: IncludeRDGW
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL:
-        Fn::Sub:
-          - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-microsoft-rdgateway/templates/rdgw-domain.template'
-          - S3Region: !If
-              - UsingDefaultBucket
-              - !Ref AWS::Region
-              - !Ref QSS3BucketRegion
-            S3Bucket: !If
-              - UsingDefaultBucket
-              - !Sub '${QSS3BucketName}-${AWS::Region}'
-              - !Ref QSS3BucketName
+      TemplateURL: !Sub
+        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-microsoft-rdgateway/templates/rdgw-domain.template'
+        - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+          S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
         DomainAdminPassword: !Ref 'DomainAdminPassword'
         DomainAdminUser: admin
@@ -514,6 +472,6 @@ Resources:
         QSS3BucketName: !Ref 'QSS3BucketName'
         QSS3BucketRegion: !Ref 'QSS3BucketRegion'
         QSS3KeyPrefix: !Sub '${QSS3KeyPrefix}submodules/quickstart-microsoft-rdgateway/'
-        RDGWInstanceType: !Ref 'RDGWInstanceType'
         RDGWCIDR: !Ref 'RDGWCIDR'
+        RDGWInstanceType: !Ref 'RDGWInstanceType'
         VPCID: !GetAtt 'VPCStack.Outputs.VPCID'

--- a/templates/mgmt-1.template
+++ b/templates/mgmt-1.template
@@ -1,9 +1,7 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >-
-  This template creates 1 Windows 2019 Server 
-  Enterpsie CA into a private subnet inside a VPC. **WARNING** This template creates Amazon
-  EC2 Windows instance and related resources. You will be billed for the AWS resources
-  used if you create a stack from this template. (qs-1qup6rae5)
+  This template creates 1 Windows 2019 Server Enterpsie CA into a private subnet inside a VPC. **WARNING** This template creates Amazon EC2 Windows
+  instance and related resources. You will be billed for the AWS resources used if you create a stack from this template. (qs-1qup6rae5)
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -38,92 +36,48 @@ Metadata:
           - QSS3KeyPrefix
           - QSS3BucketRegion
     ParameterLabels:
-      VPCCIDR:
-        default: VPC CIDR
-      VPCID:
-        default: VPC ID
-      MgmtServerSubnet:
-        default: Management Server Subnet ID
-      DomainMembersSG:
-        default: Security Group ID for Domain Members Security Group
-      MgmtServerInstanceType:
-        default: Management Server Instance Type
-      MgmtDataDriveSizeGiB:
-        default: Data Drive Size
-      KeyPairName:
-        default: Key Pair Name
-      MgmtAmi:
-        default: SSM Parameter Value for lastest AMI ID
       AdministratorSecret:
         default: Secret ARN Containing Administrator Credentials
       DirectoryID:
         default: Directory Services ID
-      MgmtServerNetBIOSName:
-        default: Management Server NetBIOS Name
       DomainController1IP:
         default: IP the Instance will be used for DNS (Must be accessible)
       DomainController2IP:
         default: IP the Instance will be used for DNS (Must be accessible)
       DomainDNSName:
         default: Domain DNS Name
+      DomainMembersSG:
+        default: Security Group ID for Domain Members Security Group
       DomainNetBIOSName:
         default: Domain NetBIOS Name
+      KeyPairName:
+        default: Key Pair Name
+      MgmtAmi:
+        default: SSM Parameter Value for lastest AMI ID
+      MgmtDataDriveSizeGiB:
+        default: Data Drive Size
+      MgmtServerInstanceType:
+        default: Management Server Instance Type
+      MgmtServerNetBIOSName:
+        default: Management Server NetBIOS Name
+      MgmtServerSubnet:
+        default: Management Server Subnet ID
       QSS3BucketName:
         default: Quick Start S3 Bucket Name
-      QSS3KeyPrefix:
-        default: Quick Start S3 Key Prefix
       QSS3BucketRegion:
         default: Quick Start S3 Bucket Region
+      QSS3KeyPrefix:
+        default: Quick Start S3 Key Prefix
+      VPCCIDR:
+        default: VPC CIDR
+      VPCID:
+        default: VPC ID
 Parameters:
-  VPCCIDR:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
-    Default: 10.0.0.0/16
-    Description: CIDR Block for the VPC
-    Type: String
-  VPCID:
-    Description: ID of the VPC (e.g., vpc-0343606e)
-    Type: AWS::EC2::VPC::Id
-  MgmtServerSubnet:
-    Description: ID of the Management Instance subnet (e.g., subnet-a0246dcd)
-    Type: AWS::EC2::Subnet::Id
-  DomainMembersSG:
-    Description: Security Group ID for Domain Members Security Group
-    Type: String
-  MgmtServerInstanceType:
-    AllowedValues:
-      - t2.small
-      - t3.small
-      - t2.medium
-      - t3.medium
-      - t2.large
-      - t3.large
-    Default: t3.medium
-    Description: Amazon EC2 instance type for the Management Server instances
-    Type: String
-  MgmtDataDriveSizeGiB:
-    Default: '2'
-    Description: Size of the data drive in GiB
-    Type: 'Number'
-  KeyPairName:
-    Description: Public/private key pairs allow you to securely connect to your instance
-      after it launches
-    Type: AWS::EC2::KeyPair::KeyName
-  MgmtAmi:
-    Default: '/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base'
-    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
   AdministratorSecret:
     Description: ARN for the Administrator credentials Secret
     Type: String
   DirectoryID:
     Description: The Directory Services ID of the AWS Managed Microsoft AD Domain
-    Type: String
-  MgmtServerNetBIOSName:
-    AllowedPattern: '[a-zA-Z0-9\-]+'
-    Default: MGMT01
-    Description: NetBIOS name of the Management Server (up to 15 characters)
-    MaxLength: '15'
-    MinLength: '1'
     Type: String
   DomainController1IP:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
@@ -139,17 +93,54 @@ Parameters:
     MaxLength: '255'
     MinLength: '2'
     Type: String
+  DomainMembersSG:
+    Description: Security Group ID for Domain Members Security Group
+    Type: String
   DomainNetBIOSName:
     AllowedPattern: '[a-zA-Z0-9\-]+'
     Description: NetBIOS name of the domain (up to 15 characters) for users of earlier versions of Windows e.g. EXAMPLE
     MaxLength: '15'
     MinLength: '1'
     Type: String
+  KeyPairName:
+    Description: Public/private key pairs allow you to securely connect to your instance after it launches
+    Type: AWS::EC2::KeyPair::KeyName
+  MgmtAmi:
+    Default: /aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+  MgmtDataDriveSizeGiB:
+    Default: '2'
+    Description: Size of the data drive in GiB
+    Type: Number
+  MgmtServerInstanceType:
+    AllowedValues:
+      - t2.small
+      - t3.small
+      - t2.medium
+      - t3.medium
+      - t2.large
+      - t3.large
+    Default: t3.medium
+    Description: Amazon EC2 instance type for the Management Server instances
+    Type: String
+  MgmtServerNetBIOSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+'
+    Default: MGMT01
+    Description: NetBIOS name of the Management Server (up to 15 characters)
+    MaxLength: '15'
+    MinLength: '1'
+    Type: String
+  MgmtServerSubnet:
+    Description: ID of the Management Instance subnet (e.g., subnet-a0246dcd)
+    Type: AWS::EC2::Subnet::Id
   QSS3BucketName:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
-    ConstraintDescription: Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)
+    ConstraintDescription:
+      Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)
     Default: aws-quickstart
-    Description: S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)
+    Description:
+      S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-).
+      It cannot start or end with a hyphen (-)
     Type: String
   QSS3BucketRegion:
     Default: us-east-1
@@ -159,8 +150,19 @@ Parameters:
     AllowedPattern: ^[0-9a-zA-Z-/]*$
     ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)
     Default: quickstart-microsoft-activedirectory/
-    Description: S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and  forward slash (/)
+    Description:
+      S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-),
+      and  forward slash (/)
     Type: String
+  VPCCIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.0.0/16
+    Description: CIDR Block for the VPC
+    Type: String
+  VPCID:
+    Description: ID of the VPC (e.g., vpc-0343606e)
+    Type: AWS::EC2::VPC::Id
 Rules:
   SubnetsInVPC:
     Assertions:
@@ -180,17 +182,33 @@ Resources:
         - PolicyDocument:
             Version: '2012-10-17'
             Statement:
-              - Action:
-                  - s3:ListBucket
-                Resource: 
-                  - !Sub ['arn:${AWS::Partition}:s3:::${S3Bucket}', S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]]
-                Effect: Allow
-              - Action:
-                  - s3:GetObject
-                Resource: 
-                  - !Sub ['arn:${AWS::Partition}:s3:::${S3Bucket}/${QSS3KeyPrefix}*', S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]]
-                Effect: Allow
-              - Action:
+              - Effect: Allow
+                Action: s3:GetObject
+                Resource:
+                  - !Sub arn:aws:s3:::aws-ssm-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::aws-windows-downloads-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::amazon-ssm-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::amazon-ssm-packages-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::${AWS::Region}-birdwatcher-prod/*
+                  - !Sub arn:aws:s3:::patch-baseline-snapshot-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::aws-ssm-distributor-file-${AWS::Region}/*
+                  - !Sub arn:aws:s3:::aws-ssm-document-attachments-${AWS::Region}/*
+          PolicyName: SSMAgent
+        - PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: s3:ListBucket
+                Resource: !Sub
+                  - 'arn:${AWS::Partition}:s3:::${S3Bucket}'
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+              - Effect: Allow
+                Action: s3:GetObject
+                Resource: !Sub
+                  - 'arn:${AWS::Partition}:s3:::${S3Bucket}/${QSS3KeyPrefix}*'
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+              - Effect: Allow
+                Action:
                   - ec2:DescribeInstances
                   - ssm:DescribeInstanceInformation
                   - ssm:ListCommands
@@ -198,15 +216,12 @@ Resources:
                   - ssm:SendCommand
                   - ssm:StartAutomationExecution
                 Resource: '*'
-                Effect: Allow
-              - Action:
-                  - cloudformation:SignalResource
+              - Effect: Allow
+                Action: cloudformation:SignalResource
                 Resource: !Sub 'arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*'
-                Effect: Allow
-              - Action:
-                  - ds:CreateConditionalForwarder
+              - Effect: Allow
+                Action: ds:CreateConditionalForwarder
                 Resource: !Sub 'arn:${AWS::Partition}:ds:${AWS::Region}:${AWS::AccountId}:directory/${DirectoryID}'
-                Effect: Allow
           PolicyName: AWS-Mgmt-Quick-Start-Policy
         - PolicyDocument:
             Version: '2012-10-17'
@@ -215,21 +230,22 @@ Resources:
                 Action:
                   - secretsmanager:GetSecretValue
                   - secretsmanager:DescribeSecret
-                Resource: 
-                  - !Ref 'AdministratorSecret'
+                Resource: !Ref 'AdministratorSecret'
           PolicyName: AWS-Mgd-AD-Secret-Policy
       Path: /
       ManagedPolicyArns:
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy'
+      Tags:
+        - Key: StackName
+          Value: !Ref AWS::StackName
       AssumeRolePolicyDocument:
         Statement:
-          - Action:
-              - sts:AssumeRole
+          - Effect: Allow
+            Action: sts:AssumeRole
             Principal:
               Service:
                 - ec2.amazonaws.com
-            Effect: Allow
         Version: '2012-10-17'
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -241,246 +257,229 @@ Resources:
     Type: AWS::SSM::Document
     Properties:
       DocumentType: Automation
+      Tags:
+        - Key: StackName
+          Value: !Ref AWS::StackName
       Content:
-        schemaVersion: "0.3"
-        description: "Deploy AD with SSM Automation"
+        schemaVersion: '0.3'
+        description: 'Deploy AD with SSM Automation'
         # Gathering parameters needed to configure DCs in the Quick Start
-        parameters: 
+        parameters:
           VPCCIDR:
             default: '10.0.0.0/16'
-            description: "CIDR Block for the VPC"
-            type: "String"
+            description: 'CIDR Block for the VPC'
+            type: 'String'
           AdministratorSecret:
-            description: "AWS Secrets Parameter Name that has Password and User namer for the domain administrator."
-            type: "String"
+            description: 'AWS Secrets Parameter Name that has Password and User namer for the domain administrator.'
+            type: 'String'
           DirectoryID:
-            description: "The Directory Services ID of the AWS Managed Microsoft AD Domain"
-            type: "String"
+            description: 'The Directory Services ID of the AWS Managed Microsoft AD Domain'
+            type: 'String'
           MgmtServerNetBIOSName:
-            description: "NetBIOS name of the Management Instance server (up to 15 characters)"
-            type: "String"
+            description: 'NetBIOS name of the Management Instance server (up to 15 characters)'
+            type: 'String'
           DomainController1IP:
-            description: "IP of DNS server that can resolve domain (Must be accessible)"
-            type: "String"
+            description: 'IP of DNS server that can resolve domain (Must be accessible)'
+            type: 'String'
           DomainController2IP:
-            description: "IP of DNS server that can resolve domain (Must be accessible)"
-            type: "String"
-          DomainDNSName: 
-            description: "Fully qualified domain name (FQDN) of the forest root domain e.g. example.com"
-            type: "String"
-          DomainNetBIOSName: 
-            description: "NetBIOS name of the domain (up to 15 characters) for users of earlier versions of Windows e.g. EXAMPLE"
-            type: "String"
+            description: 'IP of DNS server that can resolve domain (Must be accessible)'
+            type: 'String'
+          DomainDNSName:
+            description: 'Fully qualified domain name (FQDN) of the forest root domain e.g. example.com'
+            type: 'String'
+          DomainNetBIOSName:
+            description: 'NetBIOS name of the domain (up to 15 characters) for users of earlier versions of Windows e.g. EXAMPLE'
+            type: 'String'
           QSS3BucketName:
-            default: "aws-quickstart"
-            description: "S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)."
-            type: "String"
+            default: 'aws-quickstart'
+            description:
+              'S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and
+              hyphens (-). It cannot start or end with a hyphen (-).'
+            type: 'String'
           QSS3BucketRegion:
-            default: "us-east-1"
-            description: "The AWS Region where the Quick Start S3 bucket (QSS3BucketName) is hosted. When using your own bucket, you must specify this value."
-            type: "String"
+            default: 'us-east-1'
+            description:
+              'The AWS Region where the Quick Start S3 bucket (QSS3BucketName) is hosted. When using your own bucket, you must specify this value.'
+            type: 'String'
           QSS3KeyPrefix:
-            default: "quickstart-microsoft-activedirectory/"
-            description: "S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)."
-            type: "String"
+            default: 'quickstart-microsoft-activedirectory/'
+            description:
+              'S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens
+              (-), and forward slash (/).'
+            type: 'String'
           StackName:
-            default: ""
-            description: "Stack Name Input for cfn resource signal"
-            type: "String"
+            default: ''
+            description: 'Stack Name Input for cfn resource signal'
+            type: 'String'
           URLSuffix:
-            default: "amazonaws.com"
-            description: "AWS URL suffix"
-            type: "String"
+            default: 'amazonaws.com'
+            description: 'AWS URL suffix'
+            type: 'String'
         mainSteps:
-        # This step grabs the Instance IDs for both nodes that will be configured as DCs in the Quick Start and Instance IDs for the for next steps.
-        - name: "mgmtInstanceId"
-          action: aws:executeAwsApi
-          onFailure: "step:signalfailure"
-          nextStep: "dcsInstallDscModules"
-          inputs:
-            Service: ec2
-            Api: DescribeInstances
-            Filters:  
-            - Name: "tag:Name"
-              Values: [ "{{MgmtServerNetBIOSName}}" ]
-            - Name: "tag:aws:cloudformation:stack-name"
-              Values: ["{{StackName}}"]
-            - Name: "instance-state-name"
-              Values: [ "running" ]
-          outputs:
-          - Name: InstanceId
-            Selector: "$.Reservations[0].Instances[0].InstanceId"
-            Type: "String"
-        # Installs needed Powershell DSC Modules and components on both nodes.
-        - name: "dcsInstallDscModules"
-          action: "aws:runCommand"
-          onFailure: "step:signalfailure"
-          nextStep: "dcsLCMConfig"
-          inputs:
-            DocumentName: "AWS-RunRemoteScript"
-            InstanceIds:
-            - "{{mgmtInstanceId.InstanceId}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              sourceType: "S3"
-              sourceInfo: 
-                !Sub 
+          # This step grabs the Instance IDs for both nodes that will be configured as DCs in the Quick Start and Instance IDs for the for next steps.
+          - name: 'mgmtInstanceId'
+            action: aws:executeAwsApi
+            onFailure: 'step:signalfailure'
+            nextStep: 'dcsInstallDscModules'
+            inputs:
+              Service: ec2
+              Api: DescribeInstances
+              Filters:
+                - Name: 'tag:Name'
+                  Values: ['{{MgmtServerNetBIOSName}}']
+                - Name: 'tag:aws:cloudformation:stack-name'
+                  Values: ['{{StackName}}']
+                - Name: 'instance-state-name'
+                  Values: ['running']
+            outputs:
+              - Name: InstanceId
+                Selector: '$.Reservations[0].Instances[0].InstanceId'
+                Type: 'String'
+          # Installs needed Powershell DSC Modules and components on both nodes.
+          - name: 'dcsInstallDscModules'
+            action: 'aws:runCommand'
+            onFailure: 'step:signalfailure'
+            nextStep: 'dcsLCMConfig'
+            inputs:
+              DocumentName: 'AWS-RunRemoteScript'
+              InstanceIds:
+                - '{{mgmtInstanceId.InstanceId}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                sourceType: 'S3'
+                sourceInfo: !Sub
                   - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/install-ad-modules.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If 
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: "./install-ad-modules.ps1"
-        # Configures Local Configuration Manager on each of the nodes.
-        - name: "dcsLCMConfig"
-          action: "aws:runCommand"
-          onFailure: "step:signalfailure"
-          nextStep: "createMgmtMof"
-          inputs:
-            DocumentName: "AWS-RunRemoteScript"
-            InstanceIds:
-            - "{{mgmtInstanceId.InstanceId}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              sourceType: "S3"
-              sourceInfo: 
-                !Sub 
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+                    S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+                commandLine: './install-ad-modules.ps1'
+          # Configures Local Configuration Manager on each of the nodes.
+          - name: 'dcsLCMConfig'
+            action: 'aws:runCommand'
+            onFailure: 'step:signalfailure'
+            nextStep: 'createMgmtMof'
+            inputs:
+              DocumentName: 'AWS-RunRemoteScript'
+              InstanceIds:
+                - '{{mgmtInstanceId.InstanceId}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                sourceType: 'S3'
+                sourceInfo: !Sub
                   - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/LCM-Config.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If 
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: "./LCM-Config.ps1"
-        # Generates MOF file on second DC Node to be processed by LCM.
-        - name: "createMgmtMof"
-          action: "aws:runCommand"
-          onFailure: "step:signalfailure"
-          nextStep: "configMgmt"
-          inputs:
-            DocumentName: "AWS-RunRemoteScript"
-            InstanceIds:
-            - "{{mgmtInstanceId.InstanceId}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              sourceType: "S3"
-              sourceInfo: 
-                !Sub
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+                    S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+                commandLine: './LCM-Config.ps1'
+          # Generates MOF file on second DC Node to be processed by LCM.
+          - name: 'createMgmtMof'
+            action: 'aws:runCommand'
+            onFailure: 'step:signalfailure'
+            nextStep: 'configMgmt'
+            inputs:
+              DocumentName: 'AWS-RunRemoteScript'
+              InstanceIds:
+                - '{{mgmtInstanceId.InstanceId}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                sourceType: 'S3'
+                sourceInfo: !Sub
                   - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Invoke-MgmtInstanceConfig.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If 
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: "./Invoke-MgmtInstanceConfig.ps1  -MgmtNetBIOSName {{MgmtServerNetBIOSName}} -DomainNetBIOSName {{DomainNetBIOSName}} -DomainDNSName {{DomainDNSName}} -DomainController1IP {{DomainController1IP}} -DomainController2IP {{DomainController2IP}} -ADAdminSecParam {{AdministratorSecret}}"
-        # Kicks off DSC Configuration and loops\reboots until Node matches Configuration defined in MOF file.
-        - name: "configMgmt"
-          action: aws:runCommand
-          onFailure: "step:signalfailure"
-          nextStep: "finalConfigMgmt"
-          inputs:
-            DocumentName: AWS-RunPowerShellScript
-            InstanceIds: 
-              - "{{mgmtInstanceId.InstanceId}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              commands: 
-                - |     
-                   function DscStatusCheck () {
-                       $LCMState = (Get-DscLocalConfigurationManager).LCMState
-                       if ($LCMState -eq 'PendingConfiguration' -Or $LCMState -eq 'PendingReboot') {
-                           'returning 3010, should continue after reboot'
-                           exit 3010
-                       } else {
-                           'Completed'
-                       }
-                   }
-                   
-                   Start-DscConfiguration 'C:\AWSQuickstart\ConfigMgmt' -Wait -Verbose -Force
-                   
-                   DscStatusCheck
-        # Ensure that AD servers point to themselves for DNS
-        - name: "finalConfigMgmt"
-          action: "aws:runCommand"
-          onFailure: "step:signalfailure"
-          inputs:
-            DocumentName: "AWS-RunRemoteScript"
-            InstanceIds:
-              - "{{mgmtInstanceId.InstanceId}}"
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: "true"
-              CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
-            Parameters:
-              sourceType: S3
-              sourceInfo: 
-                !Sub 
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+                    S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+                commandLine:
+                  './Invoke-MgmtInstanceConfig.ps1  -MgmtNetBIOSName {{MgmtServerNetBIOSName}} -DomainNetBIOSName {{DomainNetBIOSName}} -DomainDNSName
+                  {{DomainDNSName}} -DomainController1IP {{DomainController1IP}} -DomainController2IP {{DomainController2IP}} -ADAdminSecParam
+                  {{AdministratorSecret}}'
+          # Kicks off DSC Configuration and loops\reboots until Node matches Configuration defined in MOF file.
+          - name: 'configMgmt'
+            action: aws:runCommand
+            onFailure: 'step:signalfailure'
+            nextStep: 'finalConfigMgmt'
+            inputs:
+              DocumentName: AWS-RunPowerShellScript
+              InstanceIds:
+                - '{{mgmtInstanceId.InstanceId}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                commands:
+                  - |
+                    function DscStatusCheck () {
+                        $LCMState = (Get-DscLocalConfigurationManager).LCMState
+                        if ($LCMState -eq 'PendingConfiguration' -Or $LCMState -eq 'PendingReboot') {
+                            'returning 3010, should continue after reboot'
+                            exit 3010
+                        } else {
+                            'Completed'
+                        }
+                    }
+
+                    Start-DscConfiguration 'C:\AWSQuickstart\ConfigMgmt' -Wait -Verbose -Force
+
+                    DscStatusCheck
+          # Ensure that AD servers point to themselves for DNS
+          - name: 'finalConfigMgmt'
+            action: 'aws:runCommand'
+            onFailure: 'step:signalfailure'
+            inputs:
+              DocumentName: 'AWS-RunRemoteScript'
+              InstanceIds:
+                - '{{mgmtInstanceId.InstanceId}}'
+              CloudWatchOutputConfig:
+                CloudWatchOutputEnabled: 'true'
+                CloudWatchLogGroupName: !Sub '/aws/Quick_Start/${AWS::StackName}'
+              Parameters:
+                sourceType: S3
+                sourceInfo: !Sub
                   - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Invoke-MgmtInstancePostConfig.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If 
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: "./Invoke-MgmtInstancePostConfig.ps1 -DirectoryID {{DirectoryID}} -VPCCIDR {{VPCCIDR}}"
-        # Determines if CFN Needs to be Signaled or if Work flow should just end
-        - name: CFNSignalEnd
-          action: aws:branch
-          inputs:
-            Choices:
-            - NextStep: signalsuccess
-              Not: 
-                Variable: "{{StackName}}"
-                StringEquals: ""
-            - NextStep: sleepend
-              Variable: "{{StackName}}"
-              StringEquals: ""
-        # If all steps complete successfully signals CFN of Success
-        - name: "signalsuccess"
-          action: "aws:executeAwsApi"
-          isEnd: True
-          inputs:
-            Service: cloudformation
-            Api: SignalResource
-            LogicalResourceId: "MgmtInstance"
-            StackName: "{{StackName}}"
-            Status: SUCCESS
-            UniqueId: "{{mgmtInstanceId.InstanceId}}"
-        # If CFN Signl Not Needed this sleep ends work flow
-        - name: "sleepend"
-          action: "aws:sleep"
-          isEnd: True
-          inputs:
-            Duration: PT1S
-        # If any steps fails signals CFN of Failure
-        - name: "signalfailure"
-          action: "aws:executeAwsApi"
-          inputs:
-            Service: cloudformation
-            Api: SignalResource
-            LogicalResourceId: "MgmtInstance"
-            StackName: "{{StackName}}"
-            Status: FAILURE
-            UniqueId: "{{mgmtInstanceId.InstanceId}}"
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+                    S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+                commandLine: './Invoke-MgmtInstancePostConfig.ps1 -DirectoryID {{DirectoryID}} -VPCCIDR {{VPCCIDR}}'
+          # Determines if CFN Needs to be Signaled or if Work flow should just end
+          - name: CFNSignalEnd
+            action: aws:branch
+            inputs:
+              Choices:
+                - NextStep: signalsuccess
+                  Not:
+                    Variable: '{{StackName}}'
+                    StringEquals: ''
+                - NextStep: sleepend
+                  Variable: '{{StackName}}'
+                  StringEquals: ''
+          # If all steps complete successfully signals CFN of Success
+          - name: 'signalsuccess'
+            action: 'aws:executeAwsApi'
+            isEnd: True
+            inputs:
+              Service: cloudformation
+              Api: SignalResource
+              LogicalResourceId: 'MgmtInstance'
+              StackName: '{{StackName}}'
+              Status: SUCCESS
+              UniqueId: '{{mgmtInstanceId.InstanceId}}'
+          # If CFN Signl Not Needed this sleep ends work flow
+          - name: 'sleepend'
+            action: 'aws:sleep'
+            isEnd: True
+            inputs:
+              Duration: PT1S
+          # If any steps fails signals CFN of Failure
+          - name: 'signalfailure'
+            action: 'aws:executeAwsApi'
+            inputs:
+              Service: cloudformation
+              Api: SignalResource
+              LogicalResourceId: 'MgmtInstance'
+              StackName: '{{StackName}}'
+              Status: FAILURE
+              UniqueId: '{{mgmtInstanceId.InstanceId}}'
   MgmtInstance:
     Type: AWS::EC2::Instance
     CreationPolicy:
@@ -495,15 +494,21 @@ Resources:
       Tags:
         - Key: Name
           Value: !Ref 'MgmtServerNetBIOSName'
+        - Key: Domain
+          Value: !Ref 'DomainDNSName'
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeSize: 60
             VolumeType: gp3
+            Encrypted: true
+            DeleteOnTermination: true
         - DeviceName: /dev/xvdf
           Ebs:
             VolumeSize: !Ref 'MgmtDataDriveSizeGiB'
             VolumeType: gp3
+            Encrypted: true
+            DeleteOnTermination: true
       SecurityGroupIds:
         - !Ref 'DomainMembersSG'
       KeyName: !Ref 'KeyPairName'


### PR DESCRIPTION
*Description of changes:*
- Formatting Updates
  - changed to single quotes per [AWS Quick Start Builder Guide](https://aws-quickstart.github.io/best-practices.html#formatting)
  - changed to single line conditions to keep it standardized
  - put `ParameterLabels` and `Parameters` in alphabetical order
  - put parameter properties in alphabetical order
  - put `Conditions` in alphabetical order
  - put resource attributes in alphabetical order, excluding `Properties` (left this as the last attribute)
  - put parameters for `AWS::CloudFormation::Stack` resources in alphabetical order
  - put `Outputs` and its attributes in alphabetical order
  - changed synxtax to short form for some functions
  - simplified some functions, by switching from `!Join` to `!Sub`
  - put IAM statement entries in order of: Effect, Action, Resource, Principal
- Tag Updates
  - added `StackName` tag to resources supporting tags, where CloudFormation doesn't apply the `aws:cloudformation:stack-name` tags.
  - added `Domain` tag to EC2 instances that points to `DomainDNSName`
  - added `Name` tag to security groups
- Updated IAM Roles with [minimum S3 bucket permissions for SSM Agent](https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent-minimum-s3-permissions.html)
- EBS Volume Updates
  - set [Encrypted](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-blockdev-template.html#cfn-ec2-blockdev-template-encrypted) attribute to `true`
  - set [DeleteOnTermination](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-blockdev-template.html#cfn-ec2-blockdev-template-deleteontermination) attribute to `true`
- PKI Updates
  - configured the `EntCaStack` resource to point directly to the `one-tier.template` PKI quickstart submodule in the `ad-1.template` and `ad-3.template`, removing the unnecessary call to `microsoft-pki.template.yaml`
  - configured the `TwoTierCAStack` resource to point directly to the `two-tier.template` PKI quickstart submodule in the `ad-1.template` and `ad-3.template`, removing the unnecessary call to `microsoft-pki.template.yaml`
  - configured the `CaAmi` parameter to `String` in the `ad-1.template` and `ad-3.template`, so that `AMI` can be configured as   `AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>` in the `one-tier.template` and `two-tier.template` from PKI quickstart.
- Other Updates
  - removed `DependsOn` attribute on resources, where dependency is already enforced by a "Ref" or "GetAtt"
  - removed `PlaceHolderSG` resource from the `ad-master-2.template`, and instead created the Security Group resource in the `ad-2.template`

*Taskcat Output:*

[PKI-NoTest.zip](https://github.com/aws-quickstart/quickstart-microsoft-activedirectory/files/5909076/PKI-NoTest.zip)
[PKI-TwoTierTest.zip](https://github.com/aws-quickstart/quickstart-microsoft-activedirectory/files/5909077/PKI-TwoTierTest.zip)
[PKI-OneTierTest.zip](https://github.com/aws-quickstart/quickstart-microsoft-activedirectory/files/5909078/PKI-OneTierTest.zip)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
