### PR TITLE
leastPrivilegeRole-yamlVPCstack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ taskcat_outputs/*
 .taskcat_overrides.yml
 .taskcat/*
 docs/index.html
+.taskcat-*.yml
+.DS_Store

--- a/templates/ad-1.template
+++ b/templates/ad-1.template
@@ -831,13 +831,26 @@ Resources:
                   - 'arn:${AWS::Partition}:s3:::${S3Bucket}/${QSS3KeyPrefix}*'
                   - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
               - Effect: Allow
+                Action: ssm:StartAutomationExecution
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:automation-definition/${AWSQuickstartActiveDirectoryDS}:$DEFAULT
+              - Effect: Allow
+                Action: ssm:SendCommand
+                Resource:
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:*:document/AWS-RunRemoteScript
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:*:document/AWS-RunPowerShellScript
+              - Effect: Allow
+                Action: ssm:SendCommand
+                Resource: !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:instance/*
+                Condition:
+                  StringEquals:
+                    'ssm:ResourceTag/aws:cloudformation:stack-name': !Ref AWS::StackName
+              - Sid: ReadOperations
+                Effect: Allow
                 Action:
                   - ec2:DescribeInstances
                   - ssm:DescribeInstanceInformation
                   - ssm:ListCommands
                   - ssm:ListCommandInvocations
-                  - ssm:SendCommand
-                  - ssm:StartAutomationExecution
                 Resource: '*'
               - Effect: Allow
                 Action: cloudformation:SignalResource

--- a/templates/ad-2.template
+++ b/templates/ad-2.template
@@ -941,13 +941,31 @@ Resources:
                   - 'arn:${AWS::Partition}:s3:::${S3Bucket}/${QSS3KeyPrefix}*'
                   - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
               - Effect: Allow
+                Action: ssm:StartAutomationExecution
+                Resource:
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:automation-definition/${AWSQuickstartActiveDirectoryDS}:$DEFAULT
+                  - !If
+                    - DoJoinAndPromote
+                    - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:automation-definition/${AWSQuickstartActiveDirectoryDSPromote}:$DEFAULT
+                    - !Ref AWS::NoValue
+              - Effect: Allow
+                Action: ssm:SendCommand
+                Resource:
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:*:document/AWS-RunRemoteScript
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:*:document/AWS-RunPowerShellScript
+              - Effect: Allow
+                Action: ssm:SendCommand
+                Resource: !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:instance/*
+                Condition:
+                  StringEquals:
+                    'ssm:ResourceTag/aws:cloudformation:stack-name': !Ref AWS::StackName
+              - Sid: ReadOperations
+                Effect: Allow
                 Action:
                   - ec2:DescribeInstances
                   - ssm:DescribeInstanceInformation
                   - ssm:ListCommands
                   - ssm:ListCommandInvocations
-                  - ssm:SendCommand
-                  - ssm:StartAutomationExecution
                 Resource: '*'
               - Effect: Allow
                 Action: cloudformation:SignalResource

--- a/templates/ad-master-1.template
+++ b/templates/ad-master-1.template
@@ -473,7 +473,7 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: !Sub
-        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template'
+        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template.yaml'
         - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
           S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:

--- a/templates/ad-master-2.template
+++ b/templates/ad-master-2.template
@@ -308,7 +308,7 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: !Sub
-        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template'
+        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template.yaml'
         - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
           S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:

--- a/templates/ad-master-3.template
+++ b/templates/ad-master-3.template
@@ -401,7 +401,7 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: !Sub
-        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template'
+        - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template.yaml'
         - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
           S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:

--- a/templates/mgmt-1.template
+++ b/templates/mgmt-1.template
@@ -160,7 +160,7 @@ Parameters:
     Default: 10.0.0.0/16
     Description: CIDR Block for the VPC
     Type: String
-  VPCID:
+  VPCID: # VPCID is required as it is being used in the Assertion Rule
     Description: ID of the VPC (e.g., vpc-0343606e)
     Type: AWS::EC2::VPC::Id
 Rules:
@@ -208,13 +208,26 @@ Resources:
                   - 'arn:${AWS::Partition}:s3:::${S3Bucket}/${QSS3KeyPrefix}*'
                   - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
               - Effect: Allow
+                Action: ssm:StartAutomationExecution
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:automation-definition/${AWSQuickstartMgmt}:$DEFAULT
+              - Effect: Allow
+                Action: ssm:SendCommand
+                Resource:
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:*:document/AWS-RunRemoteScript
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:*:document/AWS-RunPowerShellScript
+              - Effect: Allow
+                Action: ssm:SendCommand
+                Resource: !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:instance/*
+                Condition:
+                  StringEquals:
+                    'ssm:ResourceTag/aws:cloudformation:stack-name': !Ref AWS::StackName
+              - Sid: ReadOperations
+                Effect: Allow
                 Action:
                   - ec2:DescribeInstances
                   - ssm:DescribeInstanceInformation
                   - ssm:ListCommands
                   - ssm:ListCommandInvocations
-                  - ssm:SendCommand
-                  - ssm:StartAutomationExecution
                 Resource: '*'
               - Effect: Allow
                 Action: cloudformation:SignalResource


### PR DESCRIPTION
*Description of changes:*
- Improved `ADServerRole` per principle of least privilege
  - `ssm:SendCommand` was restricted to only the `AWS-RunRemoteScript` and `AWS-RunPowerShellScript` documents.
  - `ssm:SendCommand` was restricted to only the EC2 instances being created in these CloudFormation stacks, by validating
    `aws:cloudformation:stack-name` tag.
  - `ssm:StartAutomationExecution` was restricted to only the automation documents created in this CloudFormation stack.
  - added `SID: ReadOperations` for the statement with "\*" operations, so its clear.
- Updated the parent stacks, to use the updated [yaml VPCStack](https://github.com/aws-quickstart/quickstart-aws-vpc/blob/main/templates/aws-vpc.template.yaml)
  - the [json VPCStack](https://github.com/aws-quickstart/quickstart-aws-vpc/blob/main/templates/aws-vpc.template) is not updated/maintained

*Taskcat Output:*
[Tests.zip](https://github.com/aws-quickstart/quickstart-microsoft-activedirectory/files/5935981/Tests.zip)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
