### PR TITLE
Feature non win domain join

### DIFF
--- a/scripts/Modules/Module-AD/Module-AD.psm1
+++ b/scripts/Modules/Module-AD/Module-AD.psm1
@@ -1231,3 +1231,176 @@ Function Update-PolMigTable {
     #$PolMigTableContentExample.destination = "Example@$FQDN"
     $PolMigTable.Save($PolMigTablePath)
 }
+
+Function Set-NonWindowsDomainJoin-Credentials{
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory = $True)][String]$SecretArn,
+        [Parameter(Mandatory = $True)][PSCredential]$Credential
+    )
+    #==================================================
+    # Main
+    #==================================================
+
+    Write-Output "Getting Secret $SecretArn"
+    Try {
+        $SecretContent = Get-SECSecretValue -SecretId $SecretArn -ErrorAction Stop | Select-Object -ExpandProperty 'SecretString' | ConvertFrom-Json -ErrorAction Stop
+    } Catch [System.Exception] {
+        Write-Output "Failed to get $SecretArn Secret $_"
+        Exit 1
+    }
+
+    $AccountName = $SecretContent.awsSeamlessDomainUsername
+    $AccountPassword = $SecretContent.awsSeamlessDomainPassword
+
+    Set-CredSSP -Action 'Enable'
+    Invoke-Command -Authentication 'Credssp' -ComputerName $env:COMPUTERNAME -Credential $Credential -ScriptBlock {
+        Write-Output "Creating AD User $Using:AccountName"
+        Try {
+            New-ADUser -Name $Using:AccountName `
+                -AccountPassword (ConvertTo-SecureString ($Using:AccountPassword) -AsPlainText -Force) `
+                -ChangePasswordAtLogon $false -Enabled $true -CannotChangePassword $true  
+        } Catch [System.Exception] {
+            Write-Output "Failed to create AD User $Using:AccountName"
+            Exit 1
+        }
+        Write-Output "Setting Domain Join permissions for AD User $Using:AccountName"
+        Try {
+            $Domain = Get-ADDomain -ErrorAction Stop
+        } Catch [System.Exception] {
+            Write-Output 'Failed to get domain info'
+            Exit 1
+        }
+        $ComputersContainer = $Domain.ComputersContainer
+        Try {
+            $SchemaNamingContext = Get-ADRootDSE -ErrorAction Stop | Select-Object -ExpandProperty 'schemaNamingContext'
+        } Catch [System.Exception] {
+            Write-Output 'Failed to get domain schemaNamingContext'
+            Exit 1
+        }
+        Try {
+            [System.GUID]$ServicePrincipalNameGuid = (Get-ADObject -SearchBase $SchemaNamingContext -Filter { lDAPDisplayName -eq 'Computer' } -Properties 'schemaIDGUID' -ErrorAction Stop).schemaIDGUID 
+        } Catch [System.Exception] {
+            Write-Output 'Failed to get schemaIDGUID for computer objects'
+            Exit 1
+        }
+        Try {
+            $AccountProperties = Get-ADUser -Identity $Using:AccountName -ErrorAction Stop
+        } Catch [System.Exception] {
+            Write-Output "Failed to get AD User $Using:AccountName"
+            Exit 1
+        }
+        Try {
+            $AccountSid = New-Object -TypeName 'System.Security.Principal.SecurityIdentifier' $AccountProperties.SID.Value -ErrorAction Stop
+        } Catch [System.Exception] {
+            Write-Output "Failed to get SID for AD User $Using:AccountName"
+            Exit 1
+        }
+        Try {
+            $ObjectAcl = Get-Acl -Path "AD:\$ComputersContainer" -ErrorAction Stop
+        } Catch [System.Exception] {
+            Write-Output "Failed to get ACL for $ComputersContainer" 
+            Exit 1
+        }
+        Try {
+            $AddAccessRule = New-Object -TypeName 'System.DirectoryServices.ActiveDirectoryAccessRule' $AccountSid, 'CreateChild', 'Allow', $ServicePrincipalNameGUID, 'All' -ErrorAction Stop
+            $ObjectAcl.AddAccessRule($AddAccessRule)
+        } Catch [System.Exception] {
+            Write-Output "Failed to create ACL for $ComputersContainer" 
+            Exit 1
+        }
+        Try {
+            Set-Acl -AclObject $ObjectAcl -Path "AD:\$ComputersContainer" -ErrorAction Stop
+        } Catch [System.Exception] {
+            Write-Output "Failed to set ACL for $ComputersContainer" 
+            Exit 1
+        }
+    } # End ScriptBlog
+    Set-CredSSP -Action 'Disable'
+}
+
+Function Set-CredSSP {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][ValidateSet('Enable', 'Disable')][string]$Action
+    )
+
+    #==================================================
+    # Variables
+    #==================================================
+
+    $RootKey = 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows'
+    $CredDelKey = 'CredentialsDelegation'
+    $FreshCredKey = 'AllowFreshCredentials'
+    $FreshCredKeyNTLM = 'AllowFreshCredentialsWhenNTLMOnly'
+
+    #==================================================
+    # Main
+    #==================================================
+
+    Switch ($Action) {
+        'Enable' {
+            Write-Output 'Enabling CredSSP'
+            Try {
+                $Null = Enable-WSManCredSSP -Role 'Client' -DelegateComputer '*' -Force -ErrorAction Stop
+                $Null = Enable-WSManCredSSP -Role 'Server' -Force -ErrorAction Stop
+            } Catch [System.Exception] {
+                Write-Output "Failed to enable CredSSP $_"
+                $Null = Disable-WSManCredSSP -Role 'Client' -ErrorAction SilentlyContinue
+                $Null = Disable-WSManCredSSP -Role 'Server' -ErrorAction SilentlyContinue
+                Exit 1
+            }
+       
+            Write-Output 'Setting CredSSP Registry entries'
+            $CredDelKeyPresent = Test-Path -Path (Join-Path -Path $RootKey -ChildPath $CredDelKey) -ErrorAction SilentlyContinue
+            If (-not $CredDelKeyPresent) {
+                Try {
+                    $CredDelPath = New-Item -Path $RootKey -Name $CredDelKey -ErrorAction Stop | Select-Object -ExpandProperty 'Name'
+
+                    $FreshCredKeyPresent = Test-Path -Path (Join-Path -Path "Registry::$CredDelPath" -ChildPath $FreshCredKey) -ErrorAction SilentlyContinue
+                    If (-not $FreshCredKeyPresent) {
+                        $FreshCredKeyPath = New-Item -Path "Registry::$CredDelPath" -Name $FreshCredKey -ErrorAction Stop | Select-Object -ExpandProperty 'Name'
+                    }
+
+                    $FreshCredKeyNTLMPresent = Test-Path -Path (Join-Path -Path "Registry::$CredDelPath" -ChildPath $FreshCredKeyNTLM) -ErrorAction SilentlyContinue
+                    If (-not $FreshCredKeyNTLMPresent) {
+                        $FreshCredKeyNTLMPath = New-Item -Path "Registry::$CredDelPath" -Name $FreshCredKeyNTLM -ErrorAction Stop | Select-Object -ExpandProperty 'Name'
+                    }
+
+                    $Null = New-ItemProperty -Path "Registry::$CredDelPath" -Name 'AllowFreshCredentials' -Value '1' -PropertyType 'Dword' -Force -ErrorAction Stop
+                    $Null = New-ItemProperty -Path "Registry::$CredDelPath" -Name 'ConcatenateDefaults_AllowFresh' -Value '1' -PropertyType 'Dword' -Force -ErrorAction Stop
+                    $Null = New-ItemProperty -Path "Registry::$CredDelPath" -Name 'AllowFreshCredentialsWhenNTLMOnly' -Value '1' -PropertyType 'Dword' -Force -ErrorAction Stop
+                    $Null = New-ItemProperty -Path "Registry::$CredDelPath" -Name 'ConcatenateDefaults_AllowFreshNTLMOnly' -Value '1' -PropertyType 'Dword' -Force -ErrorAction Stop
+                    $Null = New-ItemProperty -Path "Registry::$FreshCredKeyPath" -Name '1' -Value 'WSMAN/*' -PropertyType 'String' -Force -ErrorAction Stop
+                    $Null = New-ItemProperty -Path "Registry::$FreshCredKeyNTLMPath" -Name '1' -Value 'WSMAN/*' -PropertyType 'String' -Force -ErrorAction Stop
+                } Catch [System.Exception] {
+                    Write-Output "Failed to create CredSSP Registry entries $_"
+                    Remove-Item -Path (Join-Path -Path $RootKey -ChildPath $CredDelKey) -Force -Recurse
+                    Exit 1
+                }
+            }
+        }
+        'Disable' {
+            Write-Output 'Disabling CredSSP'
+            Try {
+                Disable-WSManCredSSP -Role 'Client' -ErrorAction Continue
+                Disable-WSManCredSSP -Role 'Server' -ErrorAction Stop
+            } Catch [System.Exception] {
+                Write-Output "Failed to disable CredSSP $_"
+                Exit 1
+            }
+
+            Write-Output 'Removing CredSSP Registry entries'
+            Try {
+                Remove-Item -Path (Join-Path -Path $RootKey -ChildPath $CredDelKey) -Force -Recurse
+            } Catch [System.Exception] {
+                Write-Output "Failed to remove CredSSP Registry entries $_"
+                Exit 1
+            }
+        }
+        Default { 
+            Write-Output 'InvalidArgument: Invalid value is passed for parameter Type' 
+            Exit 1
+        }
+    }
+}

--- a/templates/ad-3.template.yaml
+++ b/templates/ad-3.template.yaml
@@ -29,6 +29,7 @@ Metadata:
           - DomainDNSName
           - DomainNetBIOSName
           - DomainAdminPassword
+          - NonWindowsDomainJoin
           - ADEdition
       - Label:
           default: Microsoft Windows Server management instance
@@ -97,6 +98,8 @@ Metadata:
         default: Management Server Instance Type
       MgmtServerNetBIOSName:
         default: Management Server NetBIOS Name
+      NonWindowsDomainJoin:
+        default: Whether to create an AD user with minimum permissions that can be used by non-Windows instances to join the domain
       OrCaServerNetBIOSName:
         default: Offline Root CA NetBIOS Name (Only Used For Two Tier PKI)
       OrCaValidityPeriodUnits:
@@ -238,6 +241,15 @@ Parameters:
     MaxLength: '15'
     MinLength: '1'
     Type: String
+  NonWindowsDomainJoin:
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Default: 'false'
+    Description: |
+      Do you want to create an AD User with minimal permissions allowing non-Windows instances to join the domain.
+      The username and password will be stored in Secrets Manager and a policy to access the secret will be created.
+    Type: String
   OrCaServerNetBIOSName:
     AllowedPattern: '[a-zA-Z0-9\-]+'
     Default: ORCA1
@@ -301,6 +313,11 @@ Parameters:
     Description: ID of the VPC (e.g., vpc-0343606e)
     Type: AWS::EC2::VPC::Id
 Rules:
+  NonWindowsDomainJoin:
+    RuleCondition: !Equals [!Ref NonWindowsDomainJoin, 'true']
+    Assertions:
+      - AssertDescription: To enable creation of an AD user for non-Windows Domain joins, you need to create a Management Server Instance
+        Assert: !Equals [!Ref MgmtServer, 'true']
   SubnetsInVPC:
     Assertions:
       - Assert: !EachMemberIn
@@ -319,6 +336,7 @@ Rules:
 Conditions:
   ShouldCreateDHCPOption: !Not [!Equals [!Ref DHCPOptionSet, 'No']]
   ShouldCreateMgmtServer: !Equals [!Ref MgmtServer, 'true']
+  ShouldCreateNonWindowsDomainJoinADUser: !Equals [!Ref NonWindowsDomainJoin, 'true']
   ShouldCreateOneTierPkiResource: !Equals [!Ref PKI, 'One-Tier']
   ShouldCreateTwoTierPkiResource: !Equals [!Ref PKI, 'Two-Tier']
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
@@ -344,6 +362,31 @@ Resources:
       Name: !Sub 'ADAdminSecret-${AWS::StackName}'
       Description: Admin User Secrets for Managed AD Quick Start
       SecretString: !Sub '{"username":"Admin","password":"${DomainAdminPassword}"}'
+  NonWindowsDomainJoinSecrets:
+    Type: AWS::SecretsManager::Secret
+    Condition: ShouldCreateNonWindowsDomainJoinADUser
+    Properties:
+      Name: !Sub 'aws/directory-services/${MicrosoftAD}/seamless-domain-join'
+      Description: User Secrets for seamless domain joins in context of the Managed AD Quick Start
+      GenerateSecretString:
+        RequireEachIncludedType: True
+        SecretStringTemplate: '{"awsSeamlessDomainUsername": "awsSeamlessDomain"}'
+        GenerateStringKey: 'awsSeamlessDomainPassword'
+        PasswordLength: 32
+        ExcludePunctuation: True
+  NonWindowsDomainJoinPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Condition: ShouldCreateNonWindowsDomainJoinADUser
+    Properties: 
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Action:
+            - 'secretsmanager:GetSecretValue'
+            - 'secretsmanager:DescribeSecret'
+          Resource: !Ref NonWindowsDomainJoinSecrets
+      ManagedPolicyName: !Sub SM-Secret-DJ-${MicrosoftAD}-Read
   MicrosoftAD:
     Type: AWS::DirectoryService::MicrosoftAD
     Properties:
@@ -418,6 +461,8 @@ Resources:
         MgmtServerInstanceType: !Ref 'MgmtServerInstanceType'
         MgmtServerNetBIOSName: !Ref 'MgmtServerNetBIOSName'
         MgmtServerSubnet: !Ref 'PrivateSubnet1ID'
+        NonWindowsDomainJoin: !Ref 'NonWindowsDomainJoin'
+        NonWindowsDomainJoinSecret: !If [ShouldCreateNonWindowsDomainJoinADUser, !Ref 'NonWindowsDomainJoinSecrets', !Ref 'AWS::NoValue']
         QSS3BucketName: !Ref 'QSS3BucketName'
         QSS3BucketRegion: !Ref 'QSS3BucketRegion'
         QSS3KeyPrefix: !Ref 'QSS3KeyPrefix'
@@ -513,3 +558,11 @@ Outputs:
   DomainMemberSGID:
     Description: Domain Member Security Group ID
     Value: !Ref 'DomainMemberSG'
+  NonWindowsDomainJoinSecrets:
+    Condition: ShouldCreateNonWindowsDomainJoinADUser
+    Description: ARN for the Secret that has Password and User bane for the domain join user
+    Value: !Ref NonWindowsDomainJoinSecrets
+  NonWindowsDomainJoinPolicy:
+    Condition: ShouldCreateNonWindowsDomainJoinADUser
+    Description: ARN of the policy with permissions to read the secret holding the credentials for the domain join user
+    Value: !Ref NonWindowsDomainJoinPolicy

--- a/templates/ad-main-3.template.yaml
+++ b/templates/ad-main-3.template.yaml
@@ -39,6 +39,7 @@ Metadata:
           - DomainDNSName
           - DomainNetBIOSName
           - DomainAdminPassword
+          - NonWindowsDomainJoin
           - ADEdition
       - Label:
           default: Microsoft Windows Server management instance
@@ -108,6 +109,8 @@ Metadata:
         default: Management Server Instance Type
       MgmtServerNetBIOSName:
         default: Management Server NetBIOS Name
+      NonWindowsDomainJoin:
+        default: Whether to create an AD user with minimum permissions that can be used by non-Windows instances to join the domain
       NumberOfAZs:
         default: Number of Availability Zones
       NumberOfRDGWHosts:
@@ -259,6 +262,15 @@ Parameters:
     MaxLength: '15'
     MinLength: '1'
     Type: String
+  NonWindowsDomainJoin:
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Default: 'false'
+    Description: |
+      Do you want to create an AD User with minimal permissions allowing non-Windows instances to join the domain?
+      The username and password will be stored in Secrets Manager and a policy to access the secret will be created.
+    Type: String
   NumberOfAZs:
     AllowedValues:
       - '2'
@@ -393,6 +405,11 @@ Conditions:
   IsTwoAz: !Equals [!Ref 'NumberOfAZs', '2']
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
 Rules:
+  NonWindowsDomainJoin:
+    RuleCondition: !Equals [!Ref NonWindowsDomainJoin, 'true']
+    Assertions:
+      - AssertDescription: To enable creation of an AD user for non-Windows Domain joins, you need to create a Management Server Instance
+        Assert: !Equals [!Ref MgmtServer, 'true']
   S3CRLBucketNameValidation:
     RuleCondition: !And
       - !Equals [!Ref UseS3ForCRL, 'Yes']
@@ -442,6 +459,7 @@ Resources:
         MgmtServer: !Ref 'MgmtServer'
         MgmtServerInstanceType: !Ref 'MgmtServerInstanceType'
         MgmtServerNetBIOSName: !Ref 'MgmtServerNetBIOSName'
+        NonWindowsDomainJoin: !Ref 'NonWindowsDomainJoin'
         OrCaServerNetBIOSName: !Ref 'OrCaServerNetBIOSName'
         OrCaValidityPeriodUnits: !Ref 'OrCaValidityPeriodUnits'
         PKI: !Ref 'PKI'

--- a/templates/mgmt-1.template.yaml
+++ b/templates/mgmt-1.template.yaml
@@ -140,6 +140,17 @@ Parameters:
   MgmtServerSubnet:
     Description: ID of the Management Instance subnet (e.g., subnet-a0246dcd)
     Type: AWS::EC2::Subnet::Id
+  NonWindowsDomainJoin:
+    Description: 'Whether to create an AD user with minimum permissions that can be used by non-Windows instances to join the domain'
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Type: 'String'
+    Default: 'false'
+  NonWindowsDomainJoinSecret:
+    Description: 'ARN for the Secret that has Password and User bane for the domain join user'
+    Type: 'String'
+    Default: ''
   QSS3BucketName:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
     ConstraintDescription:
@@ -179,8 +190,14 @@ Rules:
             - VpcId
           - !RefAll 'AWS::EC2::VPC::Id'
         AssertDescription: All subnets must in the VPC
+  NonWindowsDomainJoin:
+    RuleCondition: !Equals [!Ref NonWindowsDomainJoin, 'true']
+    Assertions:
+      - AssertDescription: To create an AD domain join user, you need to provide the secret arn.
+        Assert: !Not [!Equals [!Ref NonWindowsDomainJoinSecret, '']]
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
+  ShouldCreateNonWindowsDomainJoinADUser: !Equals [!Ref NonWindowsDomainJoin, 'true']
 Resources:
   InstanceRole:
     Type: AWS::IAM::Role
@@ -255,7 +272,9 @@ Resources:
                 Action:
                   - secretsmanager:GetSecretValue
                   - secretsmanager:DescribeSecret
-                Resource: !Ref 'AdministratorSecret'
+                Resource: 
+                  - !Ref 'AdministratorSecret'
+                  - !If [ShouldCreateNonWindowsDomainJoinADUser, !Ref 'NonWindowsDomainJoinSecret', !Ref 'AWS::NoValue']
           PolicyName: AWS-Mgd-AD-Secret-Policy
       Path: /
       ManagedPolicyArns:
@@ -302,6 +321,12 @@ Resources:
             type: 'String'
           MgmtServerNetBIOSName:
             description: 'NetBIOS name of the Management Instance server (up to 15 characters)'
+            type: 'String'
+          NonWindowsDomainJoin:
+            description: 'Whether to create an AD user with minimum permissions that can be used by non-Windows instances to join the domain'
+            type: 'String'
+          NonWindowsDomainJoinSecret:
+            description: 'The Secrets Parameter Name that has Password and User bane for the domain join user'
             type: 'String'
           DomainController1IP:
             description: 'IP of DNS server that can resolve domain (Must be accessible)'
@@ -523,10 +548,16 @@ Resources:
                       Exit 1
                   }
                   Set-MgmtPostConfig -DirectoryID '{{DirectoryID}}' -VPCCIDR '{{VPCCIDR}}'
+                  If ('{{NonWindowsDomainJoin}}'  -eq 'true' )  {
+                    Write-Output "Obtaining AD Admin Credential to authorize AD actions"
+                    $AltSecretAdmin = Get-SecretInfo -Domain '{{DomainNetBIOSName}}' -SecretArn '{{AdministratorSecret}}'
+                    Set-NonWindowsDomainJoin-Credentials -SecretArn '{{NonWindowsDomainJoinSecret}}' -Credential $AltSecretAdmin.Credentials
+                  }
                   Invoke-Cleanup -VPCCIDR '{{VPCCIDR}}'
               CloudWatchOutputConfig:
                 CloudWatchOutputEnabled: true
                 CloudWatchLogGroupName: !Sub /aws/Quick_Start/${AWS::StackName}
+            nextStep: CFNSignalEnd
           - name: CFNSignalEnd
             action: aws:branch
             inputs:
@@ -619,6 +650,10 @@ Resources:
             - !Sub '"${DomainDNSName}"'
             - ';"DomainNetBIOSName"='
             - !Sub '"${DomainNetBIOSName}"'
+            - ';"NonWindowsDomainJoin"='
+            - !Sub '"${NonWindowsDomainJoin}"'
+            - ';"NonWindowsDomainJoinSecret"='
+            - !Sub '"${NonWindowsDomainJoinSecret}"'
             - ';"QSS3BucketName"='
             - !If [UsingDefaultBucket, !Sub '"${QSS3BucketName}-${AWS::Region}"', !Sub '"${QSS3BucketName}"']
             - ';"QSS3BucketRegion"='


### PR DESCRIPTION
*Issue #, if available:*
#115 
*Description of changes:*
Non-Windows instances need credentials when joining an AD domain, but giving all instances access to the Admin credential that the quickstart stores in secrets manager does not meet security best practices.
With this changes, if enabled by `NonWindowsDomainJoin=true`, an additional  set of credentials is created with minimum permissions to join the AD Domain. Rather than the highly priviledged Amin credentials, this credentials are suited to be handed out to MacOS and Linux Instances to join the domain

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
