### PR TITLE
Updating Set-DnsDscConfiguration to avoid occasional issues during MO…

### DIFF
--- a/scripts/Modules/Module-AD/Module-AD.psm1
+++ b/scripts/Modules/Module-AD/Module-AD.psm1
@@ -568,6 +568,10 @@ Function Set-DnsDscConfiguration {
     #==================================================
     # Main
     #==================================================
+
+    Write-Output 'Formatting Computer names as FQDN'
+    $ADServer1 = "$ADServer1NetBIOSName.$DomainDNSName"
+    $ADServer2 = "$ADServer2NetBIOSName.$DomainDNSName"
     
     Configuration DnsConfig {
     
@@ -619,10 +623,6 @@ Function Set-DnsDscConfiguration {
             }
         }
     }
-
-    Write-Output 'Formatting Computer names as FQDN'
-    $ADServer1 = "$ADServer1NetBIOSName.$DomainDNSName"
-    $ADServer2 = "$ADServer2NetBIOSName.$DomainDNSName"
 
     Write-Output 'Setting Cim Sessions for Each Host'
     Try {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Rearranging parameter definition for ADServer1/ADServer2 - ideally this should resolve the transient issue with the MOF files being named incorrectly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
